### PR TITLE
Add missing include

### DIFF
--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -15,6 +15,7 @@
 #include <llvm/Passes/PassPlugin.h>
 #include <llvm/Support/Path.h>
 #include <llvm/Support/YAMLParser.h>
+#include <llvm/Support/YAMLTraits.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
 using namespace llvm;

--- a/src/passes/Metadata.cpp
+++ b/src/passes/Metadata.cpp
@@ -1,4 +1,5 @@
 #include "omvll/passes/Metadata.hpp"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"


### PR DESCRIPTION
Fix errors when compiling:

```
incomplete type 'llvm::ConstantInt' named in nested name specifier

No struct named 'MappingTraits' in namespace 'llvm::yaml'
```