### PR TITLE
Fix scripts building dependencies to o-mvll

### DIFF
--- a/scripts/docker/deps/compile_cpython310.sh
+++ b/scripts/docker/deps/compile_cpython310.sh
@@ -8,8 +8,8 @@ curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz
 tar xzvf Python-3.10.7.tgz
 cd Python-3.10.7
 
-export CC=clang
-export CXX=clang++
+export CC=clang-11
+export CXX=clang++-11
 export CFLAGS="-fPIC -m64"
 
 ./configure \
@@ -21,12 +21,12 @@ export CFLAGS="-fPIC -m64"
   --disable-test-modules
 make -j$(nproc) install
 
-pushd /cpython-install
-tar czvf Python.tar.gz *
-popd
+cd /cpython-install
+#tar czvf Python.tar.gz *
+tar czvf Python-slim.tar.gz include/python3.10/ lib/libpython3.10.a lib/pkgconfig/ share/
 
 cd /cpython
 rm -rf Python-3.10.7 && rm -rf Python-3.10.7.tgz
-cp /cpython-install/Python.tar.gz /cpython/
-chown 1000:1000 /cpython/Python.tar.gz
+cp /cpython-install/Python-slim.tar.gz /cpython/
+chown 1000:1000 /cpython/Python-slim.tar.gz
 

--- a/scripts/docker/deps/compile_pybind11.sh
+++ b/scripts/docker/deps/compile_pybind11.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/sh
+# This script is used to compile pybind11
+set -ex
+
+cd /pybind11
+
+curl -LO https://github.com/pybind/pybind11/archive/refs/tags/v2.10.3.tar.gz
+tar xzvf v2.10.3.tar.gz
+cd pybind11-2.10.3
+python3 setup.py build
+tar -C build/lib/pybind11/ -f ../pybind11.tar.gz -cvz include/pybind11/ share/cmake/
+
+rm -rf /pybind11/v2.10.3.tar.gz && rm -rf /pybind11/pybind11-2.10.3
+chown 1000:1000 /pybind11/pybind11.tar.gz

--- a/scripts/docker/deps/compile_spdlog.sh
+++ b/scripts/docker/deps/compile_spdlog.sh
@@ -21,5 +21,5 @@ cmake -GNinja -S . -B /tmp/spdlog_build \
 ninja -vvv -C /tmp/spdlog_build package
 cp /tmp/spdlog_build/spdlog-1.10.0-Linux.tar.gz /spdlog/
 
-rm -rf /spdlog/v1.10.0.tar.gz && rm -rf spdlog-1.10.0
+rm -rf /spdlog/v1.10.0.tar.gz && rm -rf /spdlog/spdlog-1.10.0
 chown 1000:1000 /spdlog/spdlog-1.10.0-Linux.tar.gz


### PR DESCRIPTION
These small changes are required in order to be able to rebuild all of the o-mvll dependencies using the 
openobfuscator/omvll-ndk docker image:

```
docker run --rm -v $(pwd)/o-mvll:/o-mvll -v $(pwd)/deps/cpython:/cpython openobfuscator/omvll-ndk sh /o-mvll/scripts/docker/deps/compile_cpython310.sh
docker run --rm -v $(pwd)/o-mvll:/o-mvll -v $(pwd)/deps/pybind11:/pybind11 openobfuscator/omvll-ndk sh /o-mvll/scripts/docker/deps/compile_pybind11.sh
docker run --rm -v $(pwd)/o-mvll:/o-mvll -v $(pwd)/deps/spdlog:/spdlog openobfuscator/omvll-ndk sh /o-mvll/scripts/docker/deps/compile_spdlog.sh

cd deps/
git clone -j8 https://android.googlesource.com/toolchain/llvm-project LLVM
cd LLVM
git checkout $REVISION
cd ../..
docker run --rm -v $(pwd)/o-mvll:/o-mvll -v $(pwd)/deps/LLVM:/LLVM openobfuscator/omvll-ndk sh /o-mvll/scripts/docker/deps/compile_llvm_r25.sh

mkdir third-party
cp deps/cpython/Python-slim.tar.gz deps/pybind11/pybind11.tar.gz deps/spdlog/spdlog-1.10.0-Linux.tar.gz third-party/
cp deps/LLVM/LLVM-14.0.6git-Linux.tar.gz third-party/LLVM-14.0.6git-Linux-slim.tar.gz 
```