### PR TITLE
Find Python3 package before pybind11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,11 +23,11 @@ option(OMVLL_PY_STANDALONE   "Build OMVLL as a standalone Python module" OFF)
 find_package(LLVM 14 REQUIRED CONFIG NO_DEFAULT_PATH)
 find_package(Clang REQUIRED CONFIG. NO_DEFAULT_PATH)
 
+set(PYTHON_VERSION "3" CACHE STRING "Python version")
+find_package(Python3 COMPONENTS Development Interpreter)
+
 find_package(spdlog REQUIRED CONFIG)
 find_package(pybind11 REQUIRED CONFIG NO_DEFAULT_PATH)
-
-set(PYTHON_VERSION "3" CACHE STRING "Python version")
-find_package(Python3 COMPONENTS Development)
 
 message(STATUS "Python version: ${Python3_VERSION}")
 message(STATUS "Python lib:     ${Python3_LIBRARIES}")


### PR DESCRIPTION
Without passing `PYTHON_EXECUTABLE` and `PYTHON_LIBRARIES` on-top of the [documented CMake invocation](https://obfuscator.re/omvll/introduction/compilation/index.html), all my configurations get screwed like this:
```
-- Found PythonInterp: /usr/bin/python3.10 (found version "3.10.6")
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.10.so
...
-- Found pybind11: /usr/include (found version "2.9.1")
-- Found Python3: /path/to/Python-3.10.7/install/include/python3.10 (found version "3.10.7") found components: Development Development.Module Development.Embed
-- Python version: 3.10.7
-- Python lib:     /path/to/Python-3.10.7/install/lib/libpython3.10.a
-- Python include: /path/to/Python-3.10.7/install/include/python3.10
-- Python interpreter:
-- Found LLVM 14.0.6git
```

This patch changes the order of events. First, we find Python3 following our CMake parameters. Then we find pybind11, which will just reuse it. Now, passing an extra `PYTHON_EXECUTABLE` parameter has no effect anymore:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    PYTHON_EXECUTABLE
```