### PR TITLE
In CMake use add_subdirectory() instead of include()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,5 +201,5 @@ if(CMAKE_BUILD_TYPE MATCHES Release AND NOT OMVLL_FORCE_LOG_DEBUG)
   endif()
 endif()
 
-include("${CMAKE_CURRENT_SOURCE_DIR}/core/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/CMakeLists.txt")
+add_subdirectory("core")
+add_subdirectory("passes")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,12 +42,12 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 
 message("LLVM STATUS:
   Definitions ${LLVM_DEFINITIONS}
-  Includes    ${LLVM_INCLUDE_DIRS}
+  Includes    ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS}
   Libraries   ${LLVM_LIBRARY_DIRS}
   Targets     ${LLVM_TARGETS_TO_BUILD}"
 )
 
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,7 +7,4 @@ target_sources(OMVLL PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/Jitter.cpp
 )
 
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/plugin.cpp
-                            PROPERTIES COMPILE_FLAGS -fno-rtti)
-
 add_subdirectory("python")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,13 +1,13 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/omvll_config.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/log.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/plugin.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/utils.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/Jitter.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/omvll_config.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/log.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/plugin.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Jitter.cpp
 )
 
-set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/plugin.cpp
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/plugin.cpp
                             PROPERTIES COMPILE_FLAGS -fno-rtti)
 
-include("${CMAKE_CURRENT_LIST_DIR}/python/CMakeLists.txt")
+add_subdirectory("python")

--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -1,15 +1,16 @@
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/pylog.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/pyllvm.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/pyobf_opt.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/PyConfig.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/PyObfuscationConfig.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pylog.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pyllvm.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pyobf_opt.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/PyConfig.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/PyObfuscationConfig.cpp
 )
 
 set_source_files_properties(
-  ${CMAKE_CURRENT_LIST_DIR}/pylog.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/pyllvm.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/pyobf_opt.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/PyConfig.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/PyObfuscationConfig.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pylog.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pyllvm.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pyobf_opt.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/PyConfig.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/PyObfuscationConfig.cpp
+  TARGET_DIRECTORY OMVLL
   PROPERTIES COMPILE_FLAGS -frtti)

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,13 +1,13 @@
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/Metadata.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Metadata.cpp
 )
 
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/objcleaner/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/strings-encoding/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/arithmetic/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/flattening/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/opaque-field-access/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/opaque-constants/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/break-cfg/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/anti-hook/CMakeLists.txt")
-include("${CMAKE_CURRENT_SOURCE_DIR}/passes/cleaning/CMakeLists.txt")
+add_subdirectory("objcleaner")
+add_subdirectory("strings-encoding")
+add_subdirectory("arithmetic")
+add_subdirectory("flattening")
+add_subdirectory("opaque-field-access")
+add_subdirectory("opaque-constants")
+add_subdirectory("break-cfg")
+add_subdirectory("anti-hook")
+add_subdirectory("cleaning")

--- a/src/passes/anti-hook/CMakeLists.txt
+++ b/src/passes/anti-hook/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/AntiHook.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/AntiHook.cpp
 )

--- a/src/passes/arithmetic/CMakeLists.txt
+++ b/src/passes/arithmetic/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/Arithmetic.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Arithmetic.cpp
 )

--- a/src/passes/break-cfg/CMakeLists.txt
+++ b/src/passes/break-cfg/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/BreakControlFlow.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/BreakControlFlow.cpp
 )

--- a/src/passes/cleaning/CMakeLists.txt
+++ b/src/passes/cleaning/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/Cleaning.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Cleaning.cpp
 )

--- a/src/passes/flattening/CMakeLists.txt
+++ b/src/passes/flattening/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/ControlFlowFlattening.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ControlFlowFlattening.cpp
 )

--- a/src/passes/objcleaner/CMakeLists.txt
+++ b/src/passes/objcleaner/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/ObjCleaner.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ObjCleaner.cpp
 )

--- a/src/passes/opaque-constants/CMakeLists.txt
+++ b/src/passes/opaque-constants/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/OpaqueConstants.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/GenOpaque.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/OpaqueConstants.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/GenOpaque.cpp
 )

--- a/src/passes/opaque-field-access/CMakeLists.txt
+++ b/src/passes/opaque-field-access/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/OpaqueFieldAccess.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/OpaqueFieldAccess.cpp
 )

--- a/src/passes/strings-encoding/CMakeLists.txt
+++ b/src/passes/strings-encoding/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 target_sources(OMVLL PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/StringEncoding.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/StringEncoding.cpp
 )
 
-set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/StringEncoding.cpp
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/StringEncoding.cpp
                             PROPERTIES COMPILE_FLAGS -fno-rtti)


### PR DESCRIPTION
Moving on from `include()` to `add_subdirectory()` is the mayor change in this PR. `add_subdirectory()` mirrors the directory structure from the source-tree to the build-tree which isolates targets and their properties in a hierarchical structure. This is idiomatic usage in CMake.

On the way, I added two more fixes. Please find more details in the individual commit messages.