### PR TITLE
Find python resources

### DIFF
--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -38,6 +38,7 @@ struct yaml::MappingTraits<omvll::yaml_config_t> {
 };
 
 void init_yamlconfig(SmallVector<char>& YConfig) {
+  SINFO("Loading omvll.yml from {}", std::string{YConfig.begin(), YConfig.end()});
   if (auto Buffer = MemoryBuffer::getFile(YConfig)) {
     yaml::Input yin(**Buffer);
     yin >> omvll::PyConfig::yconfig;
@@ -54,6 +55,7 @@ void omvll::init_yamlconfig() {
     return;
   }
 
+  SINFO("Looking for omvll.yml in {}", std::string{cwd.begin(), cwd.end()});
   SmallVector<char> YConfig = cwd;
   sys::path::append(YConfig, omvll::PyConfig::YAML_FILE);
   if (sys::fs::exists(YConfig)) {
@@ -63,6 +65,7 @@ void omvll::init_yamlconfig() {
   std::string parent(cwd.begin(), cwd.end());
   while (sys::path::has_parent_path(parent)) {
     parent = sys::path::parent_path(parent);
+    SINFO("Looking for omvll.yml in {}", std::string{parent.begin(), parent.end()});
     SmallVector<char> YConfig(parent.begin(), parent.end());
     sys::path::append(YConfig, omvll::PyConfig::YAML_FILE);
     if (sys::fs::exists(YConfig)) {

--- a/src/test/core/plugin/Inputs/config_empty.py
+++ b/src/test/core/plugin/Inputs/config_empty.py
@@ -1,0 +1,6 @@
+import omvll
+from functools import lru_cache
+
+@lru_cache(maxsize=1)
+def omvll_get_config():
+    return omvll.ObfuscationConfig()

--- a/src/test/core/plugin/Inputs/omvll.yml
+++ b/src/test/core/plugin/Inputs/omvll.yml
@@ -1,0 +1,2 @@
+OMVLL_CONFIG: config_empty.py
+OMVLL_PYTHONPATH: Python-3.10.7/Lib

--- a/src/test/core/plugin/find-omvll-config-cwd.c
+++ b/src/test/core/plugin/find-omvll-config-cwd.c
@@ -1,6 +1,7 @@
 // Prepare test output dir with yml-config, py-config and fake python-libs dir
 // RUN: rm -rf %T_cwd
 // RUN: mkdir -p %T_cwd
+// RUN: mkdir -p %T_cwd/Python-3.10.7/Lib
 // RUN: cp %S/Inputs/omvll.yml %T_cwd/omvll.yml
 // RUN: cp %S/Inputs/config_empty.py %T_cwd/config_empty.py
 
@@ -12,5 +13,7 @@
 // Check that we load the yml-config from the test output dir
 // CHECK: Looking for omvll.yml in [[CWD]]
 // CHECK: Loading omvll.yml from [[CWD]]/omvll.yml
+// CHECK: OMVLL_PYTHONPATH = Python-3.10.7/Lib
+// CHECK: OMVLL_CONFIG = config_empty.py
 
 void test() {}

--- a/src/test/core/plugin/find-omvll-config-cwd.c
+++ b/src/test/core/plugin/find-omvll-config-cwd.c
@@ -1,0 +1,16 @@
+// Prepare test output dir with yml-config, py-config and fake python-libs dir
+// RUN: rm -rf %T_cwd
+// RUN: mkdir -p %T_cwd
+// RUN: cp %S/Inputs/omvll.yml %T_cwd/omvll.yml
+// RUN: cp %S/Inputs/config_empty.py %T_cwd/config_empty.py
+
+// Run clang from the test output dir
+// RUN: cd %T_cwd
+// RUN: clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -S %s -o /dev/null
+// RUN: FileCheck %s -DCWD=%T_cwd < omvll.log
+
+// Check that we load the yml-config from the test output dir
+// CHECK: Looking for omvll.yml in [[CWD]]
+// CHECK: Loading omvll.yml from [[CWD]]/omvll.yml
+
+void test() {}

--- a/src/test/core/plugin/find-omvll-config-plugindir.c
+++ b/src/test/core/plugin/find-omvll-config-plugindir.c
@@ -1,0 +1,23 @@
+// Prepare test output dir with plugin, yml-config, py-config and fake python-libs dir
+// RUN: rm -rf %T_plugindir
+// RUN: mkdir -p %T_plugindir
+// RUN: mkdir -p %T_plugindir/Python-3.10.7/Lib
+// RUN: cp %libOMVLL %T_plugindir/libOMVLL.so
+// RUN: cp %S/Inputs/omvll.yml %T_plugindir/omvll.yml
+// RUN: cp %S/Inputs/config_empty.py %T_plugindir/config_empty.py
+
+// Run clang from a different CWD and pass plugin from the test output dir
+// RUN: cd /tmp
+// RUN: rm -rf omvll.log omvll.yml
+// RUN: clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%T_plugindir/libOMVLL.so -S %s -o /dev/null
+// RUN: FileCheck %s -DPLUGIN_DIR=%T_plugindir < omvll.log
+
+// Check that we load the yml-config from the test output dir
+// CHECK: Looking for omvll.yml in /tmp
+// CHECK: Looking for omvll.yml in /
+// CHECK: Looking for omvll.yml in [[PLUGIN_DIR]]
+// CHECK: Loading omvll.yml from [[PLUGIN_DIR]]/omvll.yml
+// CHECK: OMVLL_PYTHONPATH = Python-3.10.7/Lib
+// CHECK: OMVLL_CONFIG = config_empty.py
+
+void test() {}


### PR DESCRIPTION
This patch proposes to extend the search for `omvll.yml` to folders relative to the plugin location on disk. This is an important step towards packaging the plugin with a predefined set of Python resources.

The status quo is to look for omvll.yml in all parent folders of the current working directory: https://obfuscator.re/omvll/introduction/getting-started/#yaml-configuration-file The first commit in this PR adds a test for this.

The second commit refactors the existing code. the existing test still succeeds.

Eventually, the last commit adds the desired functionality and also allows to expand relative paths based on the `omvll.yml`s path. We now also log a warning if the path/file doesn't exist.