### PR TITLE
Basic example for execution test on host machine

### DIFF
--- a/src/passes/flattening/ControlFlowFlattening.cpp
+++ b/src/passes/flattening/ControlFlowFlattening.cpp
@@ -91,6 +91,19 @@ void EmitDefaultCaseAssembly(IRBTy& IRB, Triple TT) {
       /* hasSideEffects */ true,
       /* isStackAligned */ true
     ));
+  } else if (TT.isX86()) {
+    // FIXME: This assembly may not confuse a decompiler
+    IRB.CreateCall(FType, InlineAsm::get(
+      FType,
+      R"delim(
+        nop;
+        .byte 0xF1, 0xFF;
+        .byte 0xF2, 0xA2;
+      )delim",
+      "",
+      /* hasSideEffects */ true,
+      /* isStackAligned */ true
+    ));
   } else {
     ExitOnError Exit("Unsupported target for Control-Flow Flattening obfuscation: ");
     Exit(make_error<StringError>(TT.str(), inconvertibleErrorCode()));

--- a/src/passes/flattening/ControlFlowFlattening.cpp
+++ b/src/passes/flattening/ControlFlowFlattening.cpp
@@ -105,8 +105,7 @@ void EmitDefaultCaseAssembly(IRBTy& IRB, Triple TT) {
       /* isStackAligned */ true
     ));
   } else {
-    ExitOnError Exit("Unsupported target for Control-Flow Flattening obfuscation: ");
-    Exit(make_error<StringError>(TT.str(), inconvertibleErrorCode()));
+    fatalError("Unsupported target for Control-Flow Flattening obfuscation: " + TT.str());
   }
 }
 

--- a/src/test/passes/flattening/basic-aarch64.c
+++ b/src/test/passes/flattening/basic-aarch64.c
@@ -1,0 +1,26 @@
+// REQUIRES: aarch64-registered-target
+// TODO: Add CHECK lines
+
+// RUN:                                   clang -target aarch64-linux-android -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
+
+// RUN:                                   clang -target arm64-apple-iphoneos  -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm64-apple-iphoneos  -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
+
+int check_password(const char* passwd, unsigned len) {
+  if (len != 5) {
+    return 0;
+  }
+  if (passwd[0] == 'O') {
+    if (passwd[1] == 'M') {
+      if (passwd[2] == 'V') {
+        if (passwd[3] == 'L') {
+          if (passwd[4] == 'L') {
+            return 1;
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}

--- a/src/test/passes/flattening/basic-native.c
+++ b/src/test/passes/flattening/basic-native.c
@@ -1,0 +1,38 @@
+// TODO: Require that the native target is registered.
+// TODO: Make sure Clang finds a linker on our host machine.
+
+// Failing with "ld: library not found for -lSystem" with system clang symlinked to LLVM_TOOLS_DIR
+// XFAIL: host-platform-macOS
+
+// Compilation can fail, e.g. if we insert invalid inline assembly.
+// RUN:                                   clang -fno-legacy-pass-manager                         -O1 %s -o %T/basic-native
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 %s -o %T/basic-native-obf
+
+// This execution test only fails, if the below C code is invalid.
+// RUN: %T/basic-native right
+// RUN: not %T/basic-native wrong
+
+// This execution test may fail, if our obfuscation is invalid.
+// RUN: %T/basic-native-obf right
+// RUN: not %T/basic-native-obf wrong
+
+int check_password(const char* passwd) {
+  if (passwd[0] == 'r') {
+    if (passwd[1] == 'i') {
+      if (passwd[2] == 'g') {
+        if (passwd[3] == 'h') {
+          if (passwd[4] == 't') {
+            return 0;
+          }
+        }
+      }
+    }
+  }
+  return 1;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc <= 1)
+    return 2;
+  return check_password(argv[1]);
+}

--- a/src/test/passes/flattening/config_all.py
+++ b/src/test/passes/flattening/config_all.py
@@ -1,0 +1,12 @@
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def flatten_cfg(self, mod: omvll.Module, func: omvll.Function):
+        return True
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()


### PR DESCRIPTION
Execution tests can be tricky to run on build bots, but it might be useful to have them in order to check that obfuscations produce valid executables. As a first step, this patch shows how to implement a primitive execution test that runs on the host machine. In the future we probably want to run execution in emulated environments like QEMU. There are a few open TODOs as well, but it should be good enough to see if the basics work and get a better understanding of potential issues.