### PR TITLE
Run regression tests in GitHub NDK action

### DIFF
--- a/.github/workflows/ndk.yml
+++ b/.github/workflows/ndk.yml
@@ -14,8 +14,11 @@ jobs:
           curl -LO https://data.romainthomas.fr/omvll-deps-ndk-r25.tar
           mkdir -p /tmp/third-party-ndk25
           tar xvf ./omvll-deps-ndk-r25.tar --directory=/tmp/third-party-ndk25
+          curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz
+          tar xzvf Python-3.10.7.tgz --directory=/tmp
           docker run --rm \
             -v /tmp/third-party-ndk25:/third-party \
+            -v /tmp/Python-3.10.7:/Python-3.10.7 \
             -v $GITHUB_WORKSPACE:/o-mvll \
             openobfuscator/omvll-ndk:latest bash /o-mvll/scripts/docker/ndk_r25_compile.sh
       - name: Nightly Deployment

--- a/.github/workflows/ndk.yml
+++ b/.github/workflows/ndk.yml
@@ -8,12 +8,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: O-MVLL Android NDK r25
+      - name: O-MVLL Android NDK r25c
         shell: bash
         run: |
-          curl -LO https://data.romainthomas.fr/omvll-deps-ndk-r25.tar
+          curl -LO https://open-ofuscator.build38.io/static/omvll-deps-ndk-r25c.tar
           mkdir -p /tmp/third-party-ndk25
-          tar xvf ./omvll-deps-ndk-r25.tar --directory=/tmp/third-party-ndk25
+          tar xvf ./omvll-deps-ndk-r25c.tar --directory=/tmp/third-party-ndk25
           curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz
           tar xzvf Python-3.10.7.tgz --directory=/tmp
           docker run --rm \

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -8,12 +8,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: O-MVLL Xcode 14
+      - name: O-MVLL Xcode 14.1
         shell: bash
         run: |
-          curl -LO https://data.romainthomas.fr/omvll-deps-xcode-14.tar
+          curl -LO https://open-ofuscator.build38.io/static/omvll-deps-xcode-14_1.tar
           mkdir -p /tmp/third-party-xcode14
-          tar xvf ./omvll-deps-xcode-14.tar --directory=/tmp/third-party-xcode14
+          tar xvf ./omvll-deps-xcode-14_1.tar --directory=/tmp/third-party-xcode14
           docker run --rm \
             -v /tmp/third-party-xcode14:/third-party \
             -v $GITHUB_WORKSPACE:/o-mvll \

--- a/scripts/docker/deps/compile_cpython310.sh
+++ b/scripts/docker/deps/compile_cpython310.sh
@@ -8,8 +8,8 @@ curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz
 tar xzvf Python-3.10.7.tgz
 cd Python-3.10.7
 
-export CC=clang-11
-export CXX=clang++-11
+export CC=clang-14
+export CXX=clang++-14
 export CFLAGS="-fPIC -m64"
 
 ./configure \

--- a/scripts/docker/deps/compile_llvm_r25.sh
+++ b/scripts/docker/deps/compile_llvm_r25.sh
@@ -3,8 +3,8 @@ LLVM_TARGET="AArch64;X86"
 echo "LLVM Android Version: $(git --git-dir=/LLVM/.git describe --dirty)"
 
 cmake -GNinja -S /LLVM/llvm -B /tmp/build_llvm_ndk                                                                   \
-      -DCMAKE_CXX_COMPILER=clang++-11 \
-      -DCMAKE_C_COMPILER=clang-11 \
+      -DCMAKE_CXX_COMPILER=clang++-14 \
+      -DCMAKE_C_COMPILER=clang-14 \
       -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
       -DCMAKE_BUILD_TYPE=Release                                                                        \
       -DCMAKE_INSTALL_PREFIX=/llvm-ndk-install                                              \

--- a/scripts/docker/deps/compile_llvm_r25_debug.sh
+++ b/scripts/docker/deps/compile_llvm_r25_debug.sh
@@ -3,8 +3,8 @@ LLVM_TARGET="AArch64;X86"
 echo "LLVM Android Version: $(git --git-dir=/LLVM/.git describe --dirty)"
 
 cmake -GNinja -S /LLVM/llvm -B /tmp/build_llvm_ndk                                                                   \
-      -DCMAKE_CXX_COMPILER=clang++-11 \
-      -DCMAKE_C_COMPILER=clang-11 \
+      -DCMAKE_CXX_COMPILER=clang++-14 \
+      -DCMAKE_C_COMPILER=clang-14 \
       -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                                                                        \
       -DLLVM_ENABLE_ASSERTIONS=on \

--- a/scripts/docker/deps/compile_spdlog.sh
+++ b/scripts/docker/deps/compile_spdlog.sh
@@ -10,7 +10,7 @@ cd spdlog-1.10.0
 
 export CXXFLAGS="-stdlib=libc++ -fPIC -fno-rtti -fno-exceptions -fvisibility-inlines-hidden"
 cmake -GNinja -S . -B /tmp/spdlog_build \
-      -DCMAKE_CXX_COMPILER=clang++-11 \
+      -DCMAKE_CXX_COMPILER=clang++-14 \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
       -DSPDLOG_NO_THREAD_ID=on \

--- a/scripts/docker/dockerfiles/omvll-ndk.dockerfile
+++ b/scripts/docker/dockerfiles/omvll-ndk.dockerfile
@@ -3,25 +3,13 @@ LABEL maintainer="Romain Thomas <me@romainthomas.fr>"
 RUN mkdir -p /usr/share/man/man1                                      && \
     apt-get update -y                                                 && \
     apt-get install -y --no-install-recommends                           \
-    ninja-build g++ gcc clang-11 git make ca-certificates curl unzip     \
+    ninja-build g++ gcc clang-14 git make ca-certificates curl unzip     \
     build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev   \
     libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev            \
-    libc++abi-11-dev libc++-11-dev                                       \
+    libc++abi-14-dev libc++-14-dev llvm-14-tools                         \
+    python3 python3-pip                                                  \
   && apt-get clean                                                       \
   && rm -rf /var/lib/apt/lists/*
-
-# Python 3.10.7 requires at least OpenSSL 1.1.1 while debian:stretch-slim provides OpenSSL 1.1.0.
-# Hence, we need to compile this version
-RUN curl -LO https://www.openssl.org/source/openssl-1.1.1q.tar.gz && \
-    tar xzvf ./openssl-1.1.1q.tar.gz                              && \
-    cd openssl-1.1.1q                                             && \
-    CC=clang-11 CXX=clang++-11 CFLAGS="-fPIC"                        \
-      ./config --prefix=/usr --openssldir=/usr shared             && \
-    make -j$(nproc)                                               && \
-    make -j$(nproc) install                                       && \
-    mv /usr/lib/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/       && \
-    mv /usr/lib/libssl.so.1.1    /usr/lib/x86_64-linux-gnu/       && \
-    cd .. && rm -rf openssl-1.1.1q && rm -rf openssl-1.1.1q.tar.gz
 
 # Install a recent version of cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.24.2-linux-x86_64.sh && \
@@ -29,19 +17,16 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.
     ./cmake-3.24.2-linux-x86_64.sh --skip-license --prefix=/usr/                                     && \
     rm -rf ./cmake-3.24.2-linux-x86_64.sh
 
-# Install a recent version of python3
-RUN curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz && \
-    tar xzvf Python-3.10.7.tgz                                          && \
-    cd Python-3.10.7                                                    && \
-    CC=clang-11 CXX=clang++-11 CFLAGS="-fPIC -m64"                         \
-    ./configure                                                            \
-      --enable-shared                                                      \
-      --disable-ipv6                                                       \
-      --host=x86_64-linux-gnu                                              \
-      --target=x86_64-linux-gnu                                            \
-      --build=x86_64-linux-gnu                                             \
-      --disable-test-modules                                            && \
-    make -j$(nproc) install                                             && \
-    mv /usr/local/lib/libpython3.10.so.1.0 /usr/lib/x86_64-linux-gnu/   && \
-    cd .. && rm -rf Python-3.10.7.tgz && rm -rf Python-3.10.7
-    
+RUN python3 -m pip install lit && lit --version
+RUN git config --global --add safe.directory /o-mvll
+
+# Copy in missing test dependencies from a local resource
+# FIXME: Once we update the deps-package, these 3 must be included
+RUN mkdir -p /test-deps/bin
+COPY llvm-config /test-deps/bin
+COPY clang /test-deps/bin
+RUN ln -s /test-deps/bin/clang /test-deps/bin/clang++
+
+# FIXME: Once we have the above binaries in the deps-package, we should be able
+#        to point LLVM_TOOLS_DIR=/usr/lib/llvm-14 and remove this as well
+RUN cd /usr/lib/llvm-14/bin && cp FileCheck count not /test-deps/bin/. && cd /

--- a/scripts/docker/dockerfiles/omvll-ndk.dockerfile
+++ b/scripts/docker/dockerfiles/omvll-ndk.dockerfile
@@ -1,13 +1,14 @@
-FROM debian:stretch-slim
+FROM debian:stable-slim
 LABEL maintainer="Romain Thomas <me@romainthomas.fr>"
+
 RUN mkdir -p /usr/share/man/man1                                      && \
     apt-get update -y                                                 && \
     apt-get install -y --no-install-recommends                           \
     ninja-build g++ gcc clang-14 git make ca-certificates curl unzip     \
     build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev   \
     libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev            \
-    libc++abi-14-dev libc++-14-dev llvm-14-tools                         \
-    python3 python3-pip                                                  \
+    libc++abi-14-dev libc++-14-dev llvm-14-tools llvm-14-dev             \
+    python3 python3-pip python3-venv libc6-dev                           \
   && apt-get clean                                                       \
   && rm -rf /var/lib/apt/lists/*
 
@@ -17,16 +18,13 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.
     ./cmake-3.24.2-linux-x86_64.sh --skip-license --prefix=/usr/                                     && \
     rm -rf ./cmake-3.24.2-linux-x86_64.sh
 
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 RUN python3 -m pip install lit && lit --version
 RUN git config --global --add safe.directory /o-mvll
 
-# Copy in missing test dependencies from a local resource
-# FIXME: Once we update the deps-package, these 3 must be included
+# Copy in missing test dependencies
 RUN mkdir -p /test-deps/bin
-COPY llvm-config /test-deps/bin
-COPY clang /test-deps/bin
-RUN ln -s /test-deps/bin/clang /test-deps/bin/clang++
-
-# FIXME: Once we have the above binaries in the deps-package, we should be able
-#        to point LLVM_TOOLS_DIR=/usr/lib/llvm-14 and remove this as well
-RUN cd /usr/lib/llvm-14/bin && cp FileCheck count not /test-deps/bin/. && cd /
+RUN ln -s /opt/venv/bin/lit /test-deps/bin/llvm-lit
+RUN cd /usr/lib/llvm-14/bin && cp llvm-config FileCheck count not /test-deps/bin/. && cd /

--- a/scripts/docker/dockerfiles/omvll-xcode.dockerfile
+++ b/scripts/docker/dockerfiles/omvll-xcode.dockerfile
@@ -36,7 +36,6 @@ RUN mkdir -p /usr/share/man/man1 && \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-
 ENV PATH="/osxcross/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/osxcross/lib:${LD_LIBRARY_PATH}"
 

--- a/scripts/docker/ndk_r25_compile.sh
+++ b/scripts/docker/ndk_r25_compile.sh
@@ -17,22 +17,25 @@ cd /o-mvll/src
 mkdir -p build_ndk_r25 && cd build_ndk_r25
 cmake -GNinja .. \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_CXX_COMPILER=clang++-11 \
-      -DCMAKE_C_COMPILER=clang-11 \
+      -DCMAKE_CXX_COMPILER=clang++-14 \
+      -DCMAKE_C_COMPILER=clang-14 \
       -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
       -DCMAKE_SKIP_RPATH=ON \
       -DCMAKE_SKIP_BUILD_RPATH=ON \
-      -DPYBIND11_NOPYTHON=1 \
-      -DPYTHON_EXECUTABLE=/usr/bin/python3 \
-      -DPython3_EXECUTABLE=/usr/bin/python3 \
       -DPython3_ROOT_DIR=/deps \
       -DPython3_LIBRARY=/deps/lib/libpython3.10.a \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
       -DLLVM_DIR=/deps/LLVM-14.0.6git-Linux/lib64/cmake/llvm \
-      -DClang_DIR=/deps/LLVM-14.0.6git-Linux/lib64/cmake/clang
+      -DClang_DIR=/deps/LLVM-14.0.6git-Linux/lib64/cmake/clang \
+      -DLLVM_TOOLS_DIR=/test-deps \
+      -DLLVM_EXTERNAL_LIT=/usr/local/bin/lit
+
 ninja
+
+export OMVLL_PYTHONPATH=/Python-3.10.7/Lib
+ninja check
 
 mkdir -p /o-mvll/dist
 python3 /o-mvll/scripts/package.py -t ndk_r25 /o-mvll/src/build_ndk_r25/libOMVLL.so /o-mvll/dist/omvll_ndk_r25.tar.gz

--- a/scripts/docker/xcode_14_compile.sh
+++ b/scripts/docker/xcode_14_compile.sh
@@ -2,12 +2,14 @@
 set -ex
 mkdir -p /deps && cd /deps
 
-cp /third-party/LLVM-14.0.0git-Darwin-slim.tar.gz .
-cp /third-party/Python-slim.tar.gz .
-cp /third-party/pybind11.tar.gz .
-cp /third-party/spdlog-1.10.0-Darwin.tar.gz .
+cp /third-party/omvll-deps-xcode-*/LLVM-14.0.0git-arm64-Darwin.tar.gz .
+cp /third-party/omvll-deps-xcode-*/LLVM-14.0.0git-x86_64-Darwin.tar.gz .
+cp /third-party/omvll-deps-xcode-*/Python-slim.tar.gz .
+cp /third-party/omvll-deps-xcode-*/pybind11.tar.gz .
+cp /third-party/omvll-deps-xcode-*/spdlog-1.10.0-Darwin.tar.gz .
 
-tar xzvf LLVM-14.0.0git-Darwin-slim.tar.gz
+tar xzvf LLVM-14.0.0git-arm64-Darwin.tar.gz
+tar xzvf LLVM-14.0.0git-x86_64-Darwin.tar.gz
 tar xzvf Python-slim.tar.gz
 tar xzvf pybind11.tar.gz
 tar xzvf spdlog-1.10.0-Darwin.tar.gz
@@ -25,7 +27,7 @@ export OSXCROSS_TARGET="arm64-apple-darwin22"
 
 cmake -GNinja ../.. \
       -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
-      -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET="13.0" \
       -DOSXCROSS_HOST=${OSXCROSS_HOST} \
       -DOSXCROSS_TARGET_DIR=${OSXCROSS_TARGET_DIR} \
       -DOSXCROSS_SDK=${OSXCROSS_SDK} \
@@ -37,8 +39,7 @@ cmake -GNinja ../.. \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
-      -DLLVM_DIR=/deps/LLVM-14.0.0git-Darwin/lib/cmake/llvm \
-      -DClang_DIR=/deps/LLVM-14.0.0git-Darwin/lib/cmake/clang
+      -DLLVM_DIR=/deps/LLVM-14.0.0git-arm64-Darwin/lib/cmake/llvm \
 
 ninja
 
@@ -50,7 +51,7 @@ export OSXCROSS_TARGET="x86_64-apple-darwin22"
 
 cmake -GNinja ../.. \
       -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
-      -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET="13.0" \
       -DOSXCROSS_HOST=${OSXCROSS_HOST} \
       -DOSXCROSS_TARGET_DIR=${OSXCROSS_TARGET_DIR} \
       -DOSXCROSS_SDK=${OSXCROSS_SDK} \
@@ -62,8 +63,7 @@ cmake -GNinja ../.. \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
-      -DLLVM_DIR=/deps/LLVM-14.0.0git-Darwin/lib/cmake/llvm \
-      -DClang_DIR=/deps/LLVM-14.0.0git-Darwin/lib/cmake/clang
+      -DLLVM_DIR=/deps/LLVM-14.0.0git-x86_64-Darwin/lib/cmake/llvm \
 
 ninja
 cd ..


### PR DESCRIPTION
This patch shows what we need to run regression tests for NDK in docker and proposes a Dockerfile to build the required image. The NDK workflow is running successfully in our fork already: https://github.com/build38/o-mvll/actions/runs/5147901935
```
+ ninja check
[0/1] Running O-MVLL regression tests
Running tests with: /test-deps/bin/clang
Testing plugin file: /o-mvll/src/build_ndk_r25/libOMVLL.so
OMVLL_PYTHONPATH: /Python-3.10.7/Lib
-- Testing: 4 tests, 2 workers --
PASS: O-MVLL Tests :: passes/arithmetic/xor-x86_64-darwin.c (1 of 4)
PASS: O-MVLL Tests :: passes/arithmetic/xor-aarch64.c (2 of 4)
PASS: O-MVLL Tests :: passes/arithmetic/xor-x86_64-linux.c (3 of 4)
PASS: O-MVLL Tests :: passes/strings-encoding/basic-aarch64.cpp (4 of 4)

Testing Time: 0.87s
  Passed: 4
```

This first version still contains a few hacks, but we can get rid of them as soon as we update the package of prebuilt dependencies.