### PR TITLE
Selective AArch32 Support?

### DIFF
--- a/src/passes/flattening/ControlFlowFlattening.cpp
+++ b/src/passes/flattening/ControlFlowFlattening.cpp
@@ -104,6 +104,20 @@ void EmitDefaultCaseAssembly(IRBTy& IRB, Triple TT) {
       /* hasSideEffects */ true,
       /* isStackAligned */ true
     ));
+  } else if (TT.isARM()) {
+    IRB.CreateCall(FType, InlineAsm::get(
+      FType,
+      R"delim(
+        ldr r1, [r1, #-8];
+        bl r1;
+        mov r1, r2;
+        .byte 0xF1, 0xFF;
+        .byte 0xF2, 0xA2;
+      )delim",
+      "",
+      /* hasSideEffects */ true,
+      /* isStackAligned */ true
+    ));
   } else {
     ExitOnError Exit("Unsupported target for Control-Flow Flattening obfuscation: ");
     Exit(make_error<StringError>(TT.str(), inconvertibleErrorCode()));

--- a/src/passes/flattening/ControlFlowFlattening.cpp
+++ b/src/passes/flattening/ControlFlowFlattening.cpp
@@ -91,6 +91,19 @@ void EmitDefaultCaseAssembly(IRBTy& IRB, Triple TT) {
       /* hasSideEffects */ true,
       /* isStackAligned */ true
     ));
+  } else if (TT.isX86()) {
+    // FIXME: This assembly may not confuse a decompiler
+    IRB.CreateCall(FType, InlineAsm::get(
+      FType,
+      R"delim(
+        nop;
+        .byte 0xF1, 0xFF;
+        .byte 0xF2, 0xA2;
+      )delim",
+      "",
+      /* hasSideEffects */ true,
+      /* isStackAligned */ true
+    ));
   } else {
     ExitOnError Exit("Unsupported target for Control-Flow Flattening obfuscation: ");
     Exit(make_error<StringError>(TT.str(), inconvertibleErrorCode()));

--- a/src/test/passes/arithmetic/xor-arm-android.c
+++ b/src/test/passes/arithmetic/xor-arm-android.c
@@ -1,0 +1,41 @@
+// REQUIRES: arm-registered-target
+
+// RUN:                                        clang -target arm-linux-android -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R0 %s
+// RUN: env OMVLL_CONFIG=%S/config_rounds_2.py clang -target arm-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R2 %s
+
+// R0-LABEL: memcpy_xor:
+// R0:       .LBB0_2:
+// R0:           ldrb	r3, [r1], #1
+// R0:           eor	r3, r3, #35
+// R0:           strb	r3, [r12], #1
+// R0:           subs	lr, lr, #1
+// R0:           bne	.LBB0_2
+
+// R2-LABEL: memcpy_xor:
+// R2:       .LBB0_2:
+// R2:           ldrb	r4, [r1, r3]
+// R2:           mvn	r5, r4
+// R2:           orr	r5, r5, r12
+// R2:           add	r5, r4, r5
+// R2:           add	r5, r5, #36
+// R2:           and	r4, r4, #35
+// R2:           rsb	r4, r4, #0
+// R2:           and	r6, r5, r4
+// R2:           eor	r4, r5, r4
+// R2:           add	r4, r4, r6, lsl #1
+// R2:           strb	r4, [r0, r3]
+// R2:           mvn	r4, r3
+// R2:           orr	r4, r4, lr
+// R2:           add	r4, r3, r4
+// R2:           and	r3, r3, #1
+// R2:           add	r3, r4, r3
+// R2:           add	r3, r3, #2
+// R2:           cmp	r3, r2
+// R2:           blo	.LBB0_2
+
+void memcpy_xor(char *dst, const char *src, unsigned len) {
+  for (unsigned i = 0; i < len; i += 1) {
+    dst[i] = src[i] ^ 35;
+  }
+  dst[len] = '\0';
+}

--- a/src/test/passes/flattening/basic-aarch64.c
+++ b/src/test/passes/flattening/basic-aarch64.c
@@ -1,0 +1,26 @@
+// REQUIRES: aarch64-registered-target
+// TODO: Add CHECK lines
+
+// RUN:                                   clang -target aarch64-linux-android -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
+
+// RUN:                                   clang -target arm64-apple-iphoneos  -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm64-apple-iphoneos  -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
+
+int check_password(const char* passwd, unsigned len) {
+  if (len != 5) {
+    return 0;
+  }
+  if (passwd[0] == 'O') {
+    if (passwd[1] == 'M') {
+      if (passwd[2] == 'V') {
+        if (passwd[3] == 'L') {
+          if (passwd[4] == 'L') {
+            return 1;
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}

--- a/src/test/passes/flattening/basic-arm-android.c
+++ b/src/test/passes/flattening/basic-arm-android.c
@@ -1,20 +1,8 @@
 // REQUIRES: arm-registered-target
-// XFAIL: *
 
+// TODO: Add CHECK lines
 // RUN:                                   clang -target arm-linux-android -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
-// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o /dev/null 2>&1 | FileCheck --check-prefix=ERR %s
-
-// Compilation fails with flattening enabled
-// ERR: <inline asm>:2:5: error: invalid instruction
-// ERR:     ldr x1, #-8;
-// ERR:     ^
-// ERR: <inline asm>:3:5: error: invalid instruction, did you mean: b, bl, ldr, lsr?
-// ERR:     blr x1;
-// ERR:     ^
-// ERR: <inline asm>:4:5: error: invalid instruction
-// ERR:     mov x0, x1;
-// ERR:     ^
-// ERR: 3 errors generated.
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
 
 int check_password(const char* passwd, unsigned len) {
   if (len != 5) {

--- a/src/test/passes/flattening/basic-arm-android.c
+++ b/src/test/passes/flattening/basic-arm-android.c
@@ -1,0 +1,35 @@
+// REQUIRES: arm-registered-target
+// XFAIL: *
+
+// RUN:                                   clang -target arm-linux-android -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o /dev/null 2>&1 | FileCheck --check-prefix=ERR %s
+
+// Compilation fails with flattening enabled
+// ERR: <inline asm>:2:5: error: invalid instruction
+// ERR:     ldr x1, #-8;
+// ERR:     ^
+// ERR: <inline asm>:3:5: error: invalid instruction, did you mean: b, bl, ldr, lsr?
+// ERR:     blr x1;
+// ERR:     ^
+// ERR: <inline asm>:4:5: error: invalid instruction
+// ERR:     mov x0, x1;
+// ERR:     ^
+// ERR: 3 errors generated.
+
+int check_password(const char* passwd, unsigned len) {
+  if (len != 5) {
+    return 0;
+  }
+  if (passwd[0] == 'O') {
+    if (passwd[1] == 'M') {
+      if (passwd[2] == 'V') {
+        if (passwd[3] == 'L') {
+          if (passwd[4] == 'L') {
+            return 1;
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}

--- a/src/test/passes/flattening/basic-native.c
+++ b/src/test/passes/flattening/basic-native.c
@@ -1,0 +1,38 @@
+// TODO: Require that the native target is registered.
+// TODO: Make sure Clang finds a linker on our host machine.
+
+// Failing with "ld: library not found for -lSystem" with system clang symlinked to LLVM_TOOLS_DIR
+// XFAIL: host-platform-macOS
+
+// Compilation can fail, e.g. if we insert invalid inline assembly.
+// RUN:                                   clang -fno-legacy-pass-manager                         -O1 %s -o %T/basic-native
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 %s -o %T/basic-native-obf
+
+// This execution test only fails, if the below C code is invalid.
+// RUN: %T/basic-native right
+// RUN: not %T/basic-native wrong
+
+// This execution test may fail, if our obfuscation is invalid.
+// RUN: %T/basic-native-obf right
+// RUN: not %T/basic-native-obf wrong
+
+int check_password(const char* passwd) {
+  if (passwd[0] == 'r') {
+    if (passwd[1] == 'i') {
+      if (passwd[2] == 'g') {
+        if (passwd[3] == 'h') {
+          if (passwd[4] == 't') {
+            return 0;
+          }
+        }
+      }
+    }
+  }
+  return 1;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc <= 1)
+    return 2;
+  return check_password(argv[1]);
+}

--- a/src/test/passes/flattening/config_all.py
+++ b/src/test/passes/flattening/config_all.py
@@ -1,0 +1,12 @@
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def flatten_cfg(self, mod: omvll.Module, func: omvll.Function):
+        return True
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/strings-encoding/basic-arm-android.cpp
+++ b/src/test/passes/strings-encoding/basic-arm-android.cpp
@@ -1,0 +1,35 @@
+// REQUIRES: arm-registered-target
+// REQUIRES: jit-c++
+
+// FIXME: Add JIT-support for AArch32
+// XFAIL: *
+
+// The default object contains the file-name string:
+//     RUN: clang++ -target arm-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
+//     CHECK-DEFAULT: [[FILE_NAME]]
+
+// The 'remove' configuration overwrites it with the fixed REDACTED literal:
+//     RUN: env OMVLL_CONFIG=%S/config_remove.py clang++ -fpass-plugin=%libOMVLL \
+//     RUN:         -target arm-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REMOVED  -DFILE_NAME=%s %s
+//
+//     CHECK-REMOVED-NOT: [[FILE_NAME]]
+//     CHECK-REMOVED:     REDACTED
+
+// The 'replace' configuration encodes the string and adds logic that decodes it at load-time:
+//     RUN: env OMVLL_CONFIG=%S/config_replace.py clang++ -fpass-plugin=%libOMVLL \
+//     RUN:         -target arm-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REPLACED -DFILE_NAME=%s %s
+//
+//     CHECK-REPLACED-NOT: [[FILE_NAME]]
+
+extern void *stderr;
+extern int fprintf(void * __stream, const char *__format, ...);
+
+#define LOG_ERROR(MSG) fprintf(stderr, "Error: %s (%s:%d)\n", MSG, __FILE__, __LINE__)
+
+bool check_code(int code) {
+  if (code != 2) {
+    LOG_ERROR("Wrong input");
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Support for 32-bit targets would be interesting for Android targets, even though the primary focus for O-MVLL is AArch64. . Please consider this a starting point for a discussion, not more and not less.

When it comes to multi-target support, we can distinguish three types of passes right now:

1. Target-agnostic passes, like Arithmetic, that already work
2. Passes with hardcoded inline assembly, like CFG Flattening, can be fixed individually
3. JIT-based passes, like String Encoding, that require multi-target support in the JIT

[My first commit](https://github.com/open-obfuscator/o-mvll/commit/ae1ef8cb337b156941dbe709e7597f28dd5d8b67) adds a minimal test for each of the given examples. Initially only type (1) passes. The others expectedly fail.

[My second commit](https://github.com/open-obfuscator/o-mvll/commit/1bcd1ad677bb18f6b0fda4d6d0bd5c94a7e1aded) fixes the type (2) test. While the given inline assembly might be bogus, the patch isn't very invasive. The big benefit of the change behind the fix is, that we won't bail out in the compiler backend with a cryptic error message anymore in case of an incompatible triple. Instead, we'd deliberately fail with a reasonable error message right away. This approach doesn't add a ton of complexity. We could just keep iterating. Doing it right might improve the quality of the plugin.

JIT support isn't here yet, but maybe it's not terribly complicated either. Clang and ORC are multi-target ready from the start. And we only need to run the frontend anyway, because we don't aim to *run* the code generated for the target. We only *inject* the IR into the existing module.

Please note that this is implemented on-top of https://github.com/open-obfuscator/o-mvll/pull/14 (the two first commits) and should be rebased once it landed.