### PR TITLE
Enable string-encoding to pass tests on macOS arm64-based

### DIFF
--- a/src/test/lit.cfg.py
+++ b/src/test/lit.cfg.py
@@ -1,6 +1,7 @@
 import os
 import lit
 import sys
+import platform
 from lit.llvm import llvm_config
 
 config.name = "O-MVLL Tests"
@@ -19,6 +20,15 @@ if sys.platform == 'darwin':
     config.available_features.add('host-platform-macOS')
 if sys.platform == 'win32':
     config.available_features.add('host-platform-windows')
+
+# Determine host architecture
+host_arch = platform.machine()
+
+# Allow tests to be based on the host architecture
+if host_arch == 'x86_64':
+    config.available_features.add('host-arch-x86')
+elif host_arch == 'arm64':
+    config.available_features.add('host-arch-arm64')
 
 # The tools directory defaults to LLVM_BINARY_DIR. In order to run tests with a different compiler,
 # pass the installation base path via LLVM_TOOLS_DIR at configuration time explicitly.

--- a/src/test/passes/arithmetic/xor-aarch64-android.c
+++ b/src/test/passes/arithmetic/xor-aarch64-android.c
@@ -6,12 +6,6 @@
 // RUN: env OMVLL_CONFIG=%S/config_rounds_2.py clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R2 %s
 // RUN: env OMVLL_CONFIG=%S/config_rounds_3.py clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R3 %s
 
-// RUN:                                        clang -target arm64-apple-iphoneos -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R0 %s
-// RUN: env OMVLL_CONFIG=%S/config_rounds_0.py clang -target arm64-apple-iphoneos -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R0 %s
-// RUN: env OMVLL_CONFIG=%S/config_rounds_1.py clang -target arm64-apple-iphoneos -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R1 %s
-// RUN: env OMVLL_CONFIG=%S/config_rounds_2.py clang -target arm64-apple-iphoneos -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R2 %s
-// RUN: env OMVLL_CONFIG=%S/config_rounds_3.py clang -target arm64-apple-iphoneos -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R3 %s
-
 // R0-LABEL: memcpy_xor:
 // R0:       .LBB0_2:
 // R0:           ldrb	w11, [x1], #1

--- a/src/test/passes/arithmetic/xor-aarch64-ios.c
+++ b/src/test/passes/arithmetic/xor-aarch64-ios.c
@@ -1,0 +1,83 @@
+// REQUIRES: aarch64-registered-target
+
+// RUN:                                        clang -target arm64-apple-ios -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R0 %s
+// RUN: env OMVLL_CONFIG=%S/config_rounds_0.py clang -target arm64-apple-ios -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R0 %s
+// RUN: env OMVLL_CONFIG=%S/config_rounds_1.py clang -target arm64-apple-ios -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R1 %s
+// RUN: env OMVLL_CONFIG=%S/config_rounds_2.py clang -target arm64-apple-ios -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R2 %s
+// RUN: env OMVLL_CONFIG=%S/config_rounds_3.py clang -target arm64-apple-ios -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R3 %s
+
+// R0-LABEL: _memcpy_xor:
+// R0:       LBB0_2:
+// R0:           ldrb	w11, [x1], #1
+// R0:           eor	w11, w11, w9
+// R0:           strb	w11, [x10], #1
+// R0:           subs	x8, x8, #1
+// R0:           b.ne	LBB0_2
+
+// FIXME: It seems like rounds=1 doesn't actually do anything!
+// R1-LABEL: _memcpy_xor:
+// R1:       LBB0_2:
+// R1:           ldrb	w11, [x1], #1
+// R1:           eor	w11, w11, w9
+// R1:           strb	w11, [x10], #1
+// R1:           subs	x8, x8, #1
+// R1:           b.ne	LBB0_2
+
+// R2-LABEL: _memcpy_xor:
+// R2:       LBB0_2:
+// R2:       	mov	w11, w8
+// R2:       	ldrsb	w12, [x1, x11]
+// R2:       	orn	w13, w9, w12
+// R2:       	add	w13, w12, w13
+// R2:       	add	w13, w13, #36
+// R2:       	and	w12, w12, w10
+// R2:       	neg	w12, w12
+// R2:       	eor	w14, w13, w12
+// R2:       	and	w12, w13, w12
+// R2:       	add	w12, w14, w12, lsl #1
+// R2:       	strb	w12, [x0, x11]
+// R2:       	and	w11, w8, #0x1
+// R2:       	mvn	w12, w8
+// R2:       	orr	w12, w12, #0xfffffffe
+// R2:       	add	w8, w8, w12
+// R2:       	add	w8, w8, w11
+// R2:       	add	w8, w8, #2
+// R2:       	cmp	w8, w2
+// R2:       	b.lo	LBB0_2
+
+// R3-LABEL: _memcpy_xor:
+// R3:       LBB0_2:
+// R3:       	mov	w12, w8
+// R3:       	ldrb	w13, [x1, x12]
+// R3:       	add	w14, w13, #35
+// R3:       	orr	w15, w13, w9
+// R3:       	orn	w16, w10, w13
+// R3:       	add	w13, w16, w13
+// R3:       	sub	w13, w10, w13
+// R3:       	eor	w16, w13, w14
+// R3:       	and	w13, w13, w14
+// R3:       	add	w13, w16, w13, lsl #1
+// R3:       	neg	w13, w13
+// R3:       	eor	w14, w13, w15
+// R3:       	and	w13, w13, w15
+// R3:       	add	w13, w14, w13, lsl #1
+// R3:       	strb	w13, [x0, x12]
+// R3:       	add	w12, w8, #1
+// R3:       	mvn	w13, w8
+// R3:       	orr	w13, w13, #0xfffffffe
+// R3:       	add	w13, w8, w13
+// R3:       	sub	w13, w11, w13
+// R3:       	eor	w14, w13, w12
+// R3:       	and	w12, w13, w12
+// R3:       	orr	w8, w8, #0x1
+// R3:       	add	w8, w14, w8
+// R3:       	add	w8, w8, w12, lsl #1
+// R3:       	cmp	w8, w2
+// R3:       	b.lo	LBB0_2
+
+void memcpy_xor(char *dst, const char *src, unsigned len) {
+  for (unsigned i = 0; i < len; i += 1) {
+    dst[i] = src[i] ^ 35;
+  }
+  dst[len] = '\0';
+}

--- a/src/test/passes/flattening/basic-aarch64.c
+++ b/src/test/passes/flattening/basic-aarch64.c
@@ -4,8 +4,8 @@
 // RUN:                                   clang -target aarch64-linux-android -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
 // RUN: env OMVLL_CONFIG=%S/config_all.py clang -target aarch64-linux-android -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
 
-// RUN:                                   clang -target arm64-apple-iphoneos  -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
-// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm64-apple-iphoneos  -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
+// RUN:                                   clang -target arm64-apple-ios  -fno-legacy-pass-manager                         -O1 -fno-verbose-asm -S %s -o -
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -target arm64-apple-ios  -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 -fno-verbose-asm -S %s -o -
 
 int check_password(const char* passwd, unsigned len) {
   if (len != 5) {

--- a/src/test/passes/strings-encoding/basic-aarch64.cpp
+++ b/src/test/passes/strings-encoding/basic-aarch64.cpp
@@ -1,9 +1,9 @@
 // REQUIRES: aarch64-registered-target
-// XFAIL: host-platform-macOS && host-arch-x86
+// XFAIL: host-platform-macOS
 
 // The default object contains the file-name string:
 //     RUN: clang++ -target aarch64-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
-//     RUN: clang++ -target arm64-apple-iphoneos  -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
+//     RUN: clang++ -target arm64-apple-ios  -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
 //     CHECK-DEFAULT: [[FILE_NAME]]
 
 // The 'remove' configuration overwrites it with the fixed REDACTED literal:
@@ -11,17 +11,20 @@
 //     RUN:         -target aarch64-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REMOVED  -DFILE_NAME=%s %s
 //
 //     RUN: env OMVLL_CONFIG=%S/config_remove.py clang++ -fpass-plugin=%libOMVLL -O1 \
-//     RUN:         -target arm64-apple-iphoneos  -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REMOVED  -DFILE_NAME=%s %s
+//     RUN:         -target arm64-apple-ios  -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REMOVED  -DFILE_NAME=%s %s
 //
 //     CHECK-REMOVED-NOT: [[FILE_NAME]]
 //     CHECK-REMOVED:     REDACTED
+
+// FIXME: It seems that with target `arm64-apple-ios` the pass plugin introduces a copy of the original string,
+//        this may need to be fix in the future.
 
 // The 'replace' configuration encodes the string and adds logic that decodes it at load-time:
 //     RUN: env OMVLL_CONFIG=%S/config_replace.py clang++ -fpass-plugin=%libOMVLL \
 //     RUN:         -target aarch64-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REPLACED -DFILE_NAME=%s %s
 //
 //     RUN: env OMVLL_CONFIG=%S/config_replace.py clang++ -fpass-plugin=%libOMVLL \
-//     RUN:         -target arm64-apple-iphoneos  -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REPLACED -DFILE_NAME=%s %s
+//     RUN:         -target arm64-apple-ios  -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-REPLACED -DFILE_NAME=%s %s
 //
 //     CHECK-REPLACED-NOT: [[FILE_NAME]]
 

--- a/src/test/passes/strings-encoding/basic-aarch64.cpp
+++ b/src/test/passes/strings-encoding/basic-aarch64.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aarch64-registered-target
-// XFAIL: host-platform-macOS
+// XFAIL: host-platform-macOS && host-arch-x86
 
 // The default object contains the file-name string:
 //     RUN: clang++ -target aarch64-linux-android -fno-legacy-pass-manager -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s


### PR DESCRIPTION
Now tests can differentiate upon host architecture as well.