### PR TITLE
Clang frontend rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /src/build*
 
 # clangd cache folder
-/src/.cache
+.cache
 
 # python cache folders for tests
 __pycache__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,6 @@ option(OMVLL_FORCE_LOG_DEBUG "Force the log debug output" OFF)
 option(OMVLL_PY_STANDALONE   "Build OMVLL as a standalone Python module" OFF)
 
 find_package(LLVM 14 REQUIRED CONFIG NO_DEFAULT_PATH)
-find_package(Clang REQUIRED CONFIG. NO_DEFAULT_PATH)
 
 set(PYTHON_VERSION "3" CACHE STRING "Python version")
 find_package(Python3 COMPONENTS Development Interpreter)
@@ -42,12 +41,12 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 
 message("LLVM STATUS:
   Definitions ${LLVM_DEFINITIONS}
-  Includes    ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS}
+  Includes    ${LLVM_INCLUDE_DIRS}
   Libraries   ${LLVM_LIBRARY_DIRS}
   Targets     ${LLVM_TARGETS_TO_BUILD}"
 )
 
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
@@ -146,11 +145,7 @@ endif()
 set(LLVM_LIBS_DEP
   demangle
   OrcJIT
-  AllTargetsCodeGens
-  AllTargetsMCAs
-  AllTargetsDescs
-  AllTargetsAsmParsers
-  AllTargetsDisassemblers
+  native
 )
 
 if(APPLE)
@@ -159,13 +154,11 @@ if(APPLE)
     Option
     MCJIT
   )
-  target_link_libraries(OMVLL PRIVATE
-    clangCodeGen
-    clangFrontend
-  )
 endif()
 
 if (OMVLL_PY_STANDALONE)
+  find_package(Clang REQUIRED CONFIG NO_DEFAULT_PATH)
+  include_directories(SYSTEM ${CLANG_INCLUDE_DIRS})
   set_target_properties(OMVLL PROPERTIES PREFIX "" OUTPUT_NAME "omvll" CLEAN_DIRECT_OUTPUT 1)
   list(APPEND LLVM_LIBS_DEP
     core

--- a/src/core/Jitter.cpp
+++ b/src/core/Jitter.cpp
@@ -1,4 +1,5 @@
 #include "omvll/Jitter.hpp"
+
 #include "omvll/utils.hpp"
 #include "omvll/log.hpp"
 
@@ -29,19 +30,11 @@ using namespace llvm;
 
 namespace omvll {
 
-Jitter::Jitter(const std::string& Triple) : Triple_{Triple},
-                                            Ctx_{new LLVMContext{}} {
+Jitter::Jitter(const std::string &Triple)
+    : Triple_{Triple}, Ctx_{new LLVMContext{}} {
   InitializeNativeTarget();
   InitializeNativeTargetAsmParser();
   InitializeNativeTargetAsmPrinter();
-}
-
-std::unique_ptr<Jitter> Jitter::Create(const std::string& Triple) {
-  return std::unique_ptr<Jitter>(new Jitter(Triple));
-}
-
-std::unique_ptr<Jitter> Jitter::Create() {
-  return std::unique_ptr<Jitter>(new Jitter(sys::getProcessTriple()));
 }
 
 std::unique_ptr<llvm::orc::LLJIT> Jitter::compile(llvm::Module& M) {

--- a/src/core/Jitter.cpp
+++ b/src/core/Jitter.cpp
@@ -2,28 +2,6 @@
 #include "omvll/utils.hpp"
 #include "omvll/log.hpp"
 
-#include <clang/AST/ASTConsumer.h>
-#include <clang/AST/ASTContext.h>
-#include <clang/Basic/Diagnostic.h>
-#include <clang/Basic/DiagnosticOptions.h>
-#include <clang/Basic/FileManager.h>
-#include <clang/Basic/FileSystemOptions.h>
-#include <clang/Basic/LangOptions.h>
-#include <clang/Basic/SourceManager.h>
-#include <clang/Basic/TargetInfo.h>
-#include <clang/CodeGen/CodeGenAction.h>
-#include <clang/Driver/Compilation.h>
-#include <clang/Driver/Driver.h>
-#include <clang/Frontend/CompilerInstance.h>
-#include <clang/Frontend/CompilerInvocation.h>
-#include <clang/Frontend/TextDiagnosticPrinter.h>
-#include <clang/Lex/HeaderSearch.h>
-#include <clang/Lex/HeaderSearchOptions.h>
-#include <clang/Lex/Preprocessor.h>
-#include <clang/Lex/PreprocessorOptions.h>
-#include <clang/Parse/ParseAST.h>
-#include <clang/Sema/Sema.h>
-
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/MCJIT.h>
@@ -35,6 +13,7 @@
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/PassManager.h>
+#include <llvm/IRReader/IRReader.h>
 #include <llvm/InitializePasses.h>
 #include <llvm/Object/ELFObjectFile.h>
 #include <llvm/Object/ObjectFile.h>
@@ -46,154 +25,15 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
-using namespace clang;
 using namespace llvm;
 
 namespace omvll {
 
-Jitter::Jitter(const std::string& Triple):
-  Triple_{Triple},
-  Clang_{new CompilerInstance{}},
-  DiagID_{new DiagnosticIDs{}},
-  DiagOpts_{new DiagnosticOptions{}},
-  VFS_{new vfs::InMemoryFileSystem{}},
-  Ctx_{new LLVMContext{}}
-{
-
-  InitializeAllTargetInfos();
-  InitializeAllTargets();
-  InitializeAllTargetMCs();
-  InitializeAllTargetMCAs();
-  InitializeAllAsmPrinters();
-
+Jitter::Jitter(const std::string& Triple) : Triple_{Triple},
+                                            Ctx_{new LLVMContext{}} {
+  InitializeNativeTarget();
   InitializeNativeTargetAsmParser();
-
-  /* =======================================================================================
-   * This part of the code is highly inspired from the project
-   * DragonFFI: https://github.com/aguinet/dragonffi
-   * Developed by Adrien Guinet™
-   * =======================================================================================
-   */
-
-  auto *DiagClient = new TextDiagnosticPrinter{errs(), &*DiagOpts_};
-  Diags_ = new DiagnosticsEngine{DiagID_, &*DiagOpts_, DiagClient, true};
-
-  static const char *EmptyFiles[] = {
-    "/foo.c",
-    "/bin/omvll"
-  };
-  IntrusiveRefCntPtr<vfs::OverlayFileSystem> Overlay(new vfs::OverlayFileSystem{vfs::getRealFileSystem()});
-
-  for (const char* Path : EmptyFiles) {
-    if (StringRef(Path) == "/foo.c") {
-      VFS_->addFile(Path, 0, MemoryBuffer::getMemBuffer(R"delim(
-      int main() { return 0; }
-      )delim"));
-    } else {
-      VFS_->addFile(Path, 0, MemoryBuffer::getMemBuffer("\n"));
-    }
-  }
-  Overlay->pushOverlay(VFS_);
-
-  Driver_ = std::make_unique<driver::Driver>("/bin/omvll", Triple, *Diags_,
-                                             "omvll JIT Compiler", Overlay);
-  Driver_->setCheckInputsExist(false);
-
-  std::unique_ptr<driver::Compilation> CP(Driver_->BuildCompilation({"-fsyntax-only",  "/foo.c"}));
-
-  if (!CP) {
-    fatalError("Can't instantiate Clang's driver");
-  }
-
-  const driver::JobList &Jobs = CP->getJobs();
-
-  if (Jobs.empty() || !isa<driver::Command>(*Jobs.begin())) {
-    SmallString<256> Msg;
-    llvm::raw_svector_ostream OS(Msg);
-    Jobs.Print(OS, "; ", true);
-    fatalError(OS.str().str().c_str());
-  }
-
-  const driver::Command &Cmd = cast<driver::Command>(*Jobs.begin());
-
-  // Initialize a compiler invocation object from the clang (-cc1) arguments.
-  const llvm::opt::ArgStringList &CCArgs = Cmd.getArguments();
-
-  std::unique_ptr<CompilerInvocation> CI(new CompilerInvocation{});
-
-  CompilerInvocation::CreateFromArgs(*CI, CCArgs, *Diags_);
-
-  clang::TargetOptions& TO = CI->getTargetOpts();
-  {
-    TO.Triple     = Triple;
-    TO.HostTriple = llvm::sys::getProcessTriple();
-  }
-
-  CodeGenOptions& CGO = CI->getCodeGenOpts();
-  {
-    CGO.OptimizeSize      = false;
-    CGO.OptimizationLevel = 0;
-    CGO.CodeModel         = "default";
-    CGO.RelocationModel   = Reloc::PIC_;
-  }
-
-  DiagnosticOptions& DO = CI->getDiagnosticOpts();
-  {
-    DO.ShowCarets = true;
-  }
-
-  LangOptions& LO = *CI->getLangOpts();
-  {
-    LO.LineComment      = true;
-    LO.Optimize         = false;
-    LO.C99              = true;
-    LO.C11              = true;
-    LO.CPlusPlus        = false;
-    LO.CPlusPlus11      = false;
-    LO.CPlusPlus14      = false;
-    LO.CPlusPlus17      = false;
-    LO.CPlusPlus20      = false;
-    LO.CXXExceptions    = false;
-    LO.CXXOperatorNames = false;
-    LO.Bool             = false;
-    LO.WChar            = false; // builtin in C++, typedef in C (stddef.h)
-    LO.EmitAllDecls     = true;
-
-    LO.MSVCCompat       = false;
-    LO.MicrosoftExt     = false;
-    LO.AsmBlocks        = false;
-    LO.DeclSpecKeyword  = false;
-    LO.MSBitfields      = false;
-
-    LO.GNUMode          = false;
-    LO.GNUKeywords      = false;
-    LO.GNUAsm           = false;
-  }
-
-  FrontendOptions& FO = CI->getFrontendOpts();
-  {
-    FO.ProgramAction = frontend::EmitLLVMOnly;
-  }
-
-  /* HeaderSearchOptions& HSO = */ CI->getHeaderSearchOpts();
-  {
-    /*
-     * In the future O-MVLL could welcome user-defined include dir
-     * to support #include in the Jitted code
-     */
-  }
-
-  Clang_->setInvocation(std::move(CI));
-  Clang_->setDiagnostics(&*Diags_);
-
-  FileMgr_ = new FileManager(Clang_->getFileSystemOpts(), std::move(Overlay));
-  Clang_->createSourceManager(*FileMgr_);
-  Clang_->setFileManager(&*FileMgr_);
-}
-
-Jitter::Jitter() : Jitter(sys::getProcessTriple())
-{
-
+  InitializeNativeTargetAsmPrinter();
 }
 
 std::unique_ptr<Jitter> Jitter::Create(const std::string& Triple) {
@@ -201,25 +41,7 @@ std::unique_ptr<Jitter> Jitter::Create(const std::string& Triple) {
 }
 
 std::unique_ptr<Jitter> Jitter::Create() {
-  return std::unique_ptr<Jitter>(new Jitter());
-}
-
-
-std::unique_ptr<llvm::Module> Jitter::generate(const std::string& code) {
-  return generate(code, *Ctx_);
-}
-
-std::unique_ptr<llvm::Module> Jitter::generate(const std::string& code, LLVMContext& Ctx) {
-  auto Buf = MemoryBuffer::getMemBufferCopy(code);
-  Clang_->getInvocation().getFrontendOpts().Inputs.clear();
-  Clang_->getInvocation().getFrontendOpts().Inputs.push_back(
-    FrontendInputFile(*Buf, InputKind(Language::C), false));
-
-  std::unique_ptr<CodeGenAction> action = std::make_unique<EmitLLVMOnlyAction>(&Ctx);
-  if (!Clang_->ExecuteAction(*action)) {
-    fatalError("Can't compile code");
-  }
-  return action->takeModule();
+  return std::unique_ptr<Jitter>(new Jitter(sys::getProcessTriple()));
 }
 
 std::unique_ptr<llvm::orc::LLJIT> Jitter::compile(llvm::Module& M) {

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -4,15 +4,9 @@
 #include "omvll/utils.hpp"
 #include "omvll/Jitter.hpp"
 
-#include <clang/Basic/Diagnostic.h>
-#include <clang/Basic/DiagnosticOptions.h>
-#include <clang/Basic/FileManager.h>
-#include <clang/Driver/Driver.h>
-#include <clang/Frontend/CompilerInstance.h>
-#include <clang/Frontend/CompilerInstance.h>
-
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Passes/PassPlugin.h>
+#include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 #include <llvm/Support/YAMLParser.h>
 #include <llvm/Support/YAMLTraits.h>

--- a/src/include/omvll/Jitter.hpp
+++ b/src/include/omvll/Jitter.hpp
@@ -23,25 +23,21 @@ class ObjectFile;
 namespace omvll {
 class Jitter {
 public:
-  llvm::LLVMContext& getContext() { return *Ctx_; }
+  Jitter(const std::string &Triple);
+
+  llvm::LLVMContext &getContext() { return *Ctx_; }
 
   llvm::Expected<std::unique_ptr<llvm::Module>>
-  loadModule(llvm::StringRef Path);
-  llvm::Expected<std::unique_ptr<llvm::Module>>
-  loadModule(llvm::StringRef Path, llvm::LLVMContext& Ctx);
+  loadModule(llvm::StringRef Path, llvm::LLVMContext &Ctx);
+
   std::unique_ptr<llvm::orc::LLJIT> compile(llvm::Module& M);
 
   std::unique_ptr<llvm::MemoryBuffer> jitAsm(const std::string& Asm, size_t Size);
-
-  static std::unique_ptr<Jitter> Create(const std::string& Triple);
-  static std::unique_ptr<Jitter> Create();
 
 protected:
   size_t getFunctionSize(llvm::object::ObjectFile& Obj, llvm::StringRef Name);
 
 private:
-  Jitter(const std::string& Triple);
-
   std::string Triple_;
   std::unique_ptr<llvm::LLVMContext> Ctx_;
 };

--- a/src/include/omvll/passes/anti-hook/AntiHook.hpp
+++ b/src/include/omvll/passes/anti-hook/AntiHook.hpp
@@ -17,7 +17,8 @@ struct AntiHook : llvm::PassInfoMixin<AntiHook> {
                               llvm::ModuleAnalysisManager &FAM);
 
   bool runOnFunction(llvm::Function &F);
-  private:
+
+private:
   std::unique_ptr<llvm::RandomNumberGenerator> RNG_;
   std::unique_ptr<Jitter> jitter_;
 };

--- a/src/include/omvll/passes/string-encoding/StringEncoding.hpp
+++ b/src/include/omvll/passes/string-encoding/StringEncoding.hpp
@@ -88,9 +88,8 @@ struct StringEncoding : llvm::PassInfoMixin<StringEncoding> {
     return nullptr;
   }
 
-  private:
+private:
   inline static Jitter* HOSTJIT = nullptr;
-  inline static Jitter* TARGETJIT = nullptr;
 
   void genRoutines(const std::string& Triple, EncodingInfo& EI, llvm::LLVMContext& Ctx);
   void annotateRoutine(llvm::Module& M);

--- a/src/include/omvll/passes/string-encoding/StringEncoding.hpp
+++ b/src/include/omvll/passes/string-encoding/StringEncoding.hpp
@@ -2,10 +2,10 @@
 #define OMVLL_STRING_ENCODING_H
 #include "omvll/passes/string-encoding/StringEncodingOpt.hpp"
 
-#include "llvm/Support/RandomNumberGenerator.h"
-#include "llvm/IR/PassManager.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallSet.h"
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SmallSet.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/Support/RandomNumberGenerator.h>
 #include <variant>
 
 namespace llvm {
@@ -89,7 +89,7 @@ struct StringEncoding : llvm::PassInfoMixin<StringEncoding> {
   }
 
 private:
-  inline static Jitter* HOSTJIT = nullptr;
+  inline static Jitter *HOSTJIT = nullptr;
 
   void genRoutines(const std::string& Triple, EncodingInfo& EI, llvm::LLVMContext& Ctx);
   void annotateRoutine(llvm::Module& M);

--- a/src/passes/anti-hook/AntiHook.cpp
+++ b/src/passes/anti-hook/AntiHook.cpp
@@ -8,13 +8,7 @@
 
 #include <llvm/Demangle/Demangle.h>
 #include <llvm/IR/Constants.h>
-
-#include <clang/Frontend/CompilerInstance.h>
-#include <clang/Basic/DiagnosticOptions.h>
-#include <clang/Basic/Diagnostic.h>
-#include <clang/Basic/FileManager.h>
-#include <clang/Driver/Driver.h>
-#include <clang/Frontend/CompilerInstance.h>
+#include <llvm/Support/MemoryBuffer.h>
 
 using namespace llvm;
 

--- a/src/passes/anti-hook/AntiHook.cpp
+++ b/src/passes/anti-hook/AntiHook.cpp
@@ -73,7 +73,7 @@ bool AntiHook::runOnFunction(llvm::Function &F) {
 PreservedAnalyses AntiHook::run(Module &M,
                                 ModuleAnalysisManager &FAM) {
   bool Changed = false;
-  jitter_ = Jitter::Create(M.getTargetTriple());
+  jitter_ = std::make_unique<Jitter>(M.getTargetTriple());
 
   RNG_ = M.createRNG(name());
 

--- a/src/passes/break-cfg/BreakControlFlow.cpp
+++ b/src/passes/break-cfg/BreakControlFlow.cpp
@@ -8,13 +8,6 @@
 #include "omvll/passes/break-cfg/BreakControlFlow.hpp"
 #include "omvll/utils.hpp"
 
-#include <clang/Basic/Diagnostic.h>
-#include <clang/Basic/DiagnosticOptions.h>
-#include <clang/Basic/FileManager.h>
-#include <clang/Driver/Driver.h>
-#include <clang/Frontend/CompilerInstance.h>
-#include <clang/Frontend/CompilerInstance.h>
-
 #include <llvm/Demangle/Demangle.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/IRBuilder.h>

--- a/src/passes/break-cfg/BreakControlFlow.cpp
+++ b/src/passes/break-cfg/BreakControlFlow.cpp
@@ -191,7 +191,7 @@ bool BreakControlFlow::runOnFunction(Function &F) {
 PreservedAnalyses BreakControlFlow::run(Module &M,
                                         ModuleAnalysisManager &FAM) {
   RNG_ = M.createRNG(name());
-  Jitter_ = Jitter::Create(M.getTargetTriple());
+  Jitter_ = std::make_unique<Jitter>(M.getTargetTriple());
   SINFO("[{}] Run on: {}", name(), M.getName().str());
   bool Changed = false;
   std::vector<Function*> Fs;

--- a/src/passes/strings-encoding/StringEncoding.cpp
+++ b/src/passes/strings-encoding/StringEncoding.cpp
@@ -486,9 +486,9 @@ bool StringEncoding::processGlobal(BasicBlock& BB, Instruction&, Use& Op, Global
   return true;
 }
 
-static Expected<std::string> runClangExecutable(StringRef code, StringRef dashx,
-                                                StringRef triple,
-                                                std::vector<StringRef> args) {
+static Expected<std::string>
+runClangExecutable(StringRef code, StringRef dashx, StringRef triple,
+                   const std::vector<std::string> &args) {
   std::vector<StringRef> cmd;
   cmd.reserve(args.size() + 6);
 
@@ -498,7 +498,7 @@ static Expected<std::string> runClangExecutable(StringRef code, StringRef dashx,
   cmd.push_back("-S");
   cmd.push_back("-emit-llvm");
 
-  for (StringRef arg : args)
+  for (const std::string &arg : args)
     cmd.push_back(arg);
 
   // Create the input C file and choose macthing output file name
@@ -535,13 +535,6 @@ static Expected<std::string> runClangExecutable(StringRef code, StringRef dashx,
   return outFileName;
 }
 
-static std::vector<StringRef> toStringRefArray(std::vector<std::string> strs) {
-  std::vector<StringRef> res;
-  for (const std::string &s : strs)
-    res.push_back(s);
-  return res;
-}
-
 static Error createSMDiagnosticError(llvm::SMDiagnostic &Diag) {
   std::string Msg;
   {
@@ -560,7 +553,8 @@ static Expected<std::unique_ptr<llvm::Module>> loadModule(StringRef Path,
   return M;
 }
 
-void StringEncoding::genRoutines(const std::string& Triple, EncodingInfo& EI, LLVMContext& Ctx) {
+void StringEncoding::genRoutines(const std::string &Triple, EncodingInfo &EI,
+                                 LLVMContext &Ctx) {
   std::string hostTriple = sys::getProcessTriple();
 
   if (HOSTJIT == nullptr)
@@ -580,8 +574,8 @@ void StringEncoding::genRoutines(const std::string& Triple, EncodingInfo& EI, LL
   {
     Ctx.setDiscardValueNames(false);
     std::vector<std::string> argsTM{"-target", Triple, "-std=c++17"};
-    std::string pathTM = exitOnErr(
-        runClangExecutable(externC, "cpp", Triple, toStringRefArray(argsTM)));
+    std::string pathTM =
+        exitOnErr(runClangExecutable(externC, "cpp", Triple, argsTM));
     EI.TM = exitOnErr(loadModule(pathTM, Ctx));
     annotateRoutine(*EI.TM);
   }

--- a/src/test/lit.cfg.py
+++ b/src/test/lit.cfg.py
@@ -41,6 +41,8 @@ plugin_file = os.path.join(config.omvll_plugin_dir, 'libOMVLL' + config.llvm_plu
 print("Testing plugin file:", plugin_file)
 config.substitutions.append(('%libOMVLL', plugin_file))
 
+print("Available features are:", config.available_features)
+
 # We need this to find the Python standard library
 if 'OMVLL_PYTHONPATH' in os.environ:
     print("OMVLL_PYTHONPATH:", os.environ['OMVLL_PYTHONPATH'])


### PR DESCRIPTION
 Invoke host clang to compile C++ to IR instead of shipping a frontend in the plugin

There are multiple of motivations for this change:
(1) Less code and complexity of the plugin: binary size from 70M down to 30M
(2) Avoid IR version difference between host clang and shipped frontend
(3) Host clang configuration is easier to match, i.e. we can just pass the same arguments

Points (2) and (3) guarantee compatibility between injected IR and the host IR module. This is critical because LLVM IR gives no such guarantees between different toolchain versions or forks. We can live with that when we target Android, because we
know and we can reproduce the exact target compiler version from [Goolge's android toolchain repository](https://android.googlesource.com/toolchain/llvm_android/).

iOS is a different story, because our host compiler (the official AppleClang) is known to carry a surprising amount of internal modifications on top of [its public upstream](https://github.com/apple/llvm-project). While we don't know the actual patches, we can measure that the difference is huge by comparing the ABI of the two binaries. This suggests that our previously shipped clang frontend from apple/llvm-project may generate different IR than the host compiler. Failures would be arbitrary and there is no good way to detect them. It could be errors from middle-end passes, backend crashes, silent miscompilation or it may also just work. We wouldn't know.