### PR TITLE
`basic-native`: fix execution on macOS

### DIFF
--- a/src/test/lit.cfg.py
+++ b/src/test/lit.cfg.py
@@ -2,6 +2,7 @@ import os
 import lit
 import sys
 import platform
+import subprocess
 from lit.llvm import llvm_config
 
 config.name = "O-MVLL Tests"
@@ -42,6 +43,19 @@ print("Testing plugin file:", plugin_file)
 config.substitutions.append(('%libOMVLL', plugin_file))
 
 print("Available features are:", config.available_features)
+
+extra_linker_flags = ''
+if sys.platform == 'darwin':
+    try:
+        cmd = ["xcrun", "--show-sdk-path", "--sdk", "macosx"]
+        sdk_path = subprocess.check_output(cmd, stderr=subprocess.PIPE).strip().decode()
+        print("Using SDKROOT:", sdk_path)
+        extra_linker_flags = '-Wl,-L{}/usr/lib -Wl,-lSystem'.format(sdk_path)
+    except (subprocess.CalledProcessError, OSError):
+        print("xcrun not found. Please run command: xcode-select --install")
+        exit(1)
+
+config.substitutions.append(('%EXTRA_LINKER_FLAGS', extra_linker_flags))
 
 # We need this to find the Python standard library
 if 'OMVLL_PYTHONPATH' in os.environ:

--- a/src/test/passes/flattening/basic-native.c
+++ b/src/test/passes/flattening/basic-native.c
@@ -1,12 +1,9 @@
 // TODO: Require that the native target is registered.
 // TODO: Make sure Clang finds a linker on our host machine.
 
-// Failing with "ld: library not found for -lSystem" with system clang symlinked to LLVM_TOOLS_DIR
-// XFAIL: host-platform-macOS
-
 // Compilation can fail, e.g. if we insert invalid inline assembly.
-// RUN:                                   clang -fno-legacy-pass-manager                         -O1 %s -o %T/basic-native
-// RUN: env OMVLL_CONFIG=%S/config_all.py clang -fno-legacy-pass-manager -fpass-plugin=%libOMVLL -O1 %s -o %T/basic-native-obf
+// RUN:                                   clang -fno-legacy-pass-manager                         %EXTRA_LINKER_FLAGS -O1 %s -o %T/basic-native
+// RUN: env OMVLL_CONFIG=%S/config_all.py clang -fno-legacy-pass-manager -fpass-plugin=%libOMVLL %EXTRA_LINKER_FLAGS -O1 %s -o %T/basic-native-obf
 
 // This execution test only fails, if the below C code is invalid.
 // RUN: %T/basic-native right


### PR DESCRIPTION
Extra linker flags are required for execution test when testing on macOS.