### PR TITLE
Extend clang invocation with SDK path when targeting iOS

### DIFF
--- a/src/include/omvll/passes/string-encoding/StringEncoding.hpp
+++ b/src/include/omvll/passes/string-encoding/StringEncoding.hpp
@@ -4,6 +4,7 @@
 
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallSet.h>
+#include <llvm/ADT/Triple.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Support/RandomNumberGenerator.h>
 #include <variant>
@@ -91,7 +92,8 @@ struct StringEncoding : llvm::PassInfoMixin<StringEncoding> {
 private:
   inline static Jitter *HOSTJIT = nullptr;
 
-  void genRoutines(const std::string& Triple, EncodingInfo& EI, llvm::LLVMContext& Ctx);
+  void genRoutines(const llvm::Triple &Triple, EncodingInfo &EI,
+                   llvm::LLVMContext &Ctx);
   void annotateRoutine(llvm::Module& M);
 
   std::vector<llvm::CallInst*> inline_wlist_;

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -2,6 +2,7 @@
 #define OMVLL_UTILS_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/Error.h"
 #include <string>
@@ -42,7 +43,7 @@ void shuffleFunctions(llvm::Module& M);
 [[noreturn]] void fatalError(const std::string& msg);
 
 llvm::Expected<std::unique_ptr<llvm::Module>>
-generateModule(llvm::StringRef Routine, llvm::StringRef Triple,
+generateModule(llvm::StringRef Routine, const llvm::Triple &Triple,
                llvm::StringRef Extension, llvm::LLVMContext &Ctx,
                llvm::ArrayRef<std::string> ExtraArgs);
 }


### PR DESCRIPTION
When invoking Apple Clang via `getMainExecutable`, we lack of the various options the command was invoked with. This ensures that, at the very least, Foundation header paths are properly included. Minor style convention fixes too.