### PR TITLE
Add report_diff user-callback in Python API

### DIFF
--- a/src/core/python/PyConfig.cpp
+++ b/src/core/python/PyConfig.cpp
@@ -298,7 +298,13 @@ void omvll_ctor(py::module_& m) {
          +--------------+-----------------------------------------+
 
          See the :omvll:`anti-hook` documentation.
-         )delim", "module"_a, "function"_a);
+         )delim", "module"_a, "function"_a)
+
+    .def("report_diff",
+         &ObfuscationConfig::report_diff,
+         R"delim(
+         User-callback to monitor IR-level changes from individual obfuscation passes.
+         )delim", "pass_name"_a, "original"_a, "obfuscated"_a);
 
 }
 

--- a/src/core/python/PyObfuscationConfig.cpp
+++ b/src/core/python/PyObfuscationConfig.cpp
@@ -197,6 +197,26 @@ AntiHookOpt PyObfuscationConfig::anti_hooking(llvm::Module* mod, llvm::Function*
   return false;
 }
 
+bool PyObfuscationConfig::has_report_diff_override() const {
+  const auto *base = static_cast<const ObfuscationConfig *>(this);
+  return py::get_override(base, "report_diff") ? true : false;
+}
+
+void PyObfuscationConfig::report_diff(const std::string &pass,
+                                      const std::string &original,
+                                      const std::string &obfuscated) {
+  py::gil_scoped_acquire gil;
+  py::function override = py::get_override(
+      static_cast<const ObfuscationConfig *>(this), "report_diff");
+  if (override) {
+    try {
+      override(pass, original, obfuscated);
+    } catch (const std::exception &e) {
+      fatalError("Error in 'report_diff': '"s + e.what() + "'");
+    }
+  }
+}
+
 ArithmeticOpt PyObfuscationConfig::obfuscate_arithmetic(llvm::Module* mod, llvm::Function* func)
 {
   py::gil_scoped_acquire gil;

--- a/src/core/python/PyObfuscationConfig.cpp
+++ b/src/core/python/PyObfuscationConfig.cpp
@@ -199,7 +199,7 @@ AntiHookOpt PyObfuscationConfig::anti_hooking(llvm::Module* mod, llvm::Function*
 
 bool PyObfuscationConfig::has_report_diff_override() const {
   const auto *base = static_cast<const ObfuscationConfig *>(this);
-  return py::get_override(base, "report_diff");
+  return static_cast<bool>(py::get_override(base, "report_diff"));
 }
 
 void PyObfuscationConfig::report_diff(const std::string &pass,

--- a/src/core/python/PyObfuscationConfig.cpp
+++ b/src/core/python/PyObfuscationConfig.cpp
@@ -199,7 +199,7 @@ AntiHookOpt PyObfuscationConfig::anti_hooking(llvm::Module* mod, llvm::Function*
 
 bool PyObfuscationConfig::has_report_diff_override() const {
   const auto *base = static_cast<const ObfuscationConfig *>(this);
-  return py::get_override(base, "report_diff") ? true : false;
+  return py::get_override(base, "report_diff");
 }
 
 void PyObfuscationConfig::report_diff(const std::string &pass,

--- a/src/core/python/PyObfuscationConfig.cpp
+++ b/src/core/python/PyObfuscationConfig.cpp
@@ -199,8 +199,7 @@ AntiHookOpt PyObfuscationConfig::anti_hooking(llvm::Module* mod, llvm::Function*
 }
 
 bool PyObfuscationConfig::has_report_diff_override() {
-  llvm::once_flag F;
-  llvm::call_once(F, [this]() {
+  std::call_once(overrides_report_diff_checked_, [this]() {
     const auto *base = static_cast<const ObfuscationConfig *>(this);
     overrides_report_diff_ =
         static_cast<bool>(py::get_override(base, "report_diff"));
@@ -211,7 +210,7 @@ bool PyObfuscationConfig::has_report_diff_override() {
 void PyObfuscationConfig::report_diff(const std::string &pass,
                                       const std::string &original,
                                       const std::string &obfuscated) {
-  if (overrides_report_diff_) {
+  if (has_report_diff_override()) {
     py::gil_scoped_acquire gil;
     py::function override = py::get_override(
         static_cast<const ObfuscationConfig *>(this), "report_diff");

--- a/src/core/python/PyObfuscationConfig.hpp
+++ b/src/core/python/PyObfuscationConfig.hpp
@@ -20,9 +20,12 @@ class PyObfuscationConfig : public ObfuscationConfig {
   ArithmeticOpt obfuscate_arithmetic(llvm::Module* mod, llvm::Function* func) override;
   OpaqueConstantsOpt obfuscate_constants(llvm::Module* mod, llvm::Function* func) override;
 
-  bool has_report_diff_override() const override;
+  bool has_report_diff_override() override;
   void report_diff(const std::string &pass, const std::string &original,
                    const std::string &obfuscated) override;
+
+private:
+  bool overrides_report_diff_ = false;
 };
 }
 #endif

--- a/src/core/python/PyObfuscationConfig.hpp
+++ b/src/core/python/PyObfuscationConfig.hpp
@@ -19,6 +19,10 @@ class PyObfuscationConfig : public ObfuscationConfig {
   AntiHookOpt anti_hooking(llvm::Module* mod, llvm::Function* func) override;
   ArithmeticOpt obfuscate_arithmetic(llvm::Module* mod, llvm::Function* func) override;
   OpaqueConstantsOpt obfuscate_constants(llvm::Module* mod, llvm::Function* func) override;
+
+  bool has_report_diff_override() const override;
+  void report_diff(const std::string &pass, const std::string &original,
+                   const std::string &obfuscated) override;
 };
 }
 #endif

--- a/src/core/python/PyObfuscationConfig.hpp
+++ b/src/core/python/PyObfuscationConfig.hpp
@@ -1,6 +1,7 @@
 #ifndef OMVLL_PY_OBFUSCATION_CONFIG_H
 #define OMVLL_PY_OBFUSCATION_CONFIG_H
 #include "omvll/ObfuscationConfig.hpp"
+#include <mutex>
 
 namespace omvll {
 
@@ -26,6 +27,7 @@ class PyObfuscationConfig : public ObfuscationConfig {
 
 private:
   bool overrides_report_diff_ = false;
+  std::once_flag overrides_report_diff_checked_;
 };
 }
 #endif

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -432,11 +432,9 @@ generateModule(StringRef Routine, const Triple &Triple, StringRef Extension,
 IRChangesMonitor::IRChangesMonitor(const llvm::Module &M,
                                    llvm::StringRef PassName)
     : Mod(M), UserConfig(PyConfig::instance().getUserConfig()),
-      ChangeReported(false) {
-  if (UserConfig->has_report_diff_override()) {
-    this->PassName = PassName.str();
+      PassName(PassName), ChangeReported(false) {
+  if (UserConfig->has_report_diff_override())
     llvm::raw_string_ostream(OriginalIR) << Mod;
-  }
 }
 
 PreservedAnalyses IRChangesMonitor::report() {

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -1,7 +1,7 @@
 #include "omvll/utils.hpp"
-#include "omvll/log.hpp"
 #include "omvll/ObfuscationConfig.hpp"
 #include "omvll/PyConfig.hpp"
+#include "omvll/log.hpp"
 
 #include <llvm/ADT/Hashing.h>
 #include <llvm/ADT/Optional.h>
@@ -429,7 +429,9 @@ generateModule(StringRef Routine, const Triple &Triple, StringRef Extension,
   }
 }
 
-IRChangesMonitor::IRChangesMonitor(const llvm::Module &M, llvm::StringRef PassName) : Mod(M) {
+IRChangesMonitor::IRChangesMonitor(const llvm::Module &M,
+                                   llvm::StringRef PassName)
+    : Mod(M) {
   ObfuscationConfig *UserConfig = PyConfig::instance().getUserConfig();
   if (UserConfig->has_report_diff_override()) {
     this->UserConfig = UserConfig;
@@ -443,7 +445,8 @@ PreservedAnalyses IRChangesMonitor::report() {
     std::string ObfuscatedIR;
     llvm::raw_string_ostream(ObfuscatedIR) << Mod;
     if (OriginalIR != ObfuscatedIR) {
-      assert(!ChangeReported && "Textual IR change detected that transformation didn't report");
+      assert(!ChangeReported &&
+             "Textual IR change detected that transformation didn't report");
       UserConfig->report_diff(PassName, OriginalIR, ObfuscatedIR);
     }
   }

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -445,7 +445,7 @@ PreservedAnalyses IRChangesMonitor::report() {
     std::string ObfuscatedIR;
     llvm::raw_string_ostream(ObfuscatedIR) << Mod;
     if (OriginalIR != ObfuscatedIR) {
-      assert(!ChangeReported &&
+      assert(ChangeReported &&
              "Textual IR change detected that transformation didn't report");
       UserConfig->report_diff(PassName, OriginalIR, ObfuscatedIR);
     }

--- a/src/include/omvll/ObfuscationConfig.hpp
+++ b/src/include/omvll/ObfuscationConfig.hpp
@@ -37,7 +37,7 @@ struct ObfuscationConfig {
 
   virtual AntiHookOpt anti_hooking(llvm::Module* mod, llvm::Function* func) = 0;
 
-  virtual bool has_report_diff_override() const { return false; };
+  virtual bool has_report_diff_override() { return false; };
   virtual void report_diff(const std::string &pass, const std::string &original,
                            const std::string &obfuscated) = 0;
 };

--- a/src/include/omvll/ObfuscationConfig.hpp
+++ b/src/include/omvll/ObfuscationConfig.hpp
@@ -36,6 +36,10 @@ struct ObfuscationConfig {
   virtual ArithmeticOpt obfuscate_arithmetic(llvm::Module* mod, llvm::Function* func) = 0;
 
   virtual AntiHookOpt anti_hooking(llvm::Module* mod, llvm::Function* func) = 0;
+
+  virtual bool has_report_diff_override() const { return false; };
+  virtual void report_diff(const std::string &pass, const std::string &original,
+                           const std::string &obfuscated) = 0;
 };
 
 }

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -75,6 +75,5 @@ private:
   std::string OriginalIR;
   bool ChangeReported;
 };
-
 }
 #endif

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -70,7 +70,7 @@ public:
 
 private:
   const llvm::Module &Mod;
-  ObfuscationConfig *UserConfig = nullptr;
+  ObfuscationConfig *UserConfig;
   std::string PassName;
   std::string OriginalIR;
   bool ChangeReported;

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -4,6 +4,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Support/Error.h"
 #include <string>
 
@@ -46,5 +47,34 @@ llvm::Expected<std::unique_ptr<llvm::Module>>
 generateModule(llvm::StringRef Routine, const llvm::Triple &Triple,
                llvm::StringRef Extension, llvm::LLVMContext &Ctx,
                llvm::ArrayRef<std::string> ExtraArgs);
+
+struct ObfuscationConfig;
+
+class IRChangesMonitor {
+public:
+  IRChangesMonitor(const llvm::Module &M, llvm::StringRef PassName);
+
+  // Call this function whenever a transformation in the pass reported changes
+  // explicitly. This determines the PreservedAnalyses flag returned from the
+  // report() function.
+  void notify(bool TransformationReportedChange) {
+    ChangeReported |= TransformationReportedChange;
+  }
+
+  llvm::PreservedAnalyses report();
+
+  IRChangesMonitor(IRChangesMonitor &&) = delete;
+  IRChangesMonitor(const IRChangesMonitor &) = delete;
+  IRChangesMonitor &operator=(IRChangesMonitor &&) = delete;
+  IRChangesMonitor &operator=(const IRChangesMonitor &) = delete;
+
+private:
+  const llvm::Module &Mod;
+  ObfuscationConfig *UserConfig = nullptr;
+  std::string PassName;
+  std::string OriginalIR;
+  bool ChangeReported;
+};
+
 }
 #endif

--- a/src/passes/arithmetic/Arithmetic.cpp
+++ b/src/passes/arithmetic/Arithmetic.cpp
@@ -8,10 +8,10 @@
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/IRBuilder.h"
-#include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/IR/NoFolder.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/Support/RandomNumberGenerator.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include <llvm/Support/raw_ostream.h>
 
 using namespace llvm;

--- a/src/test/passes/arithmetic/report_diff-x86_64-linux.c
+++ b/src/test/passes/arithmetic/report_diff-x86_64-linux.c
@@ -1,7 +1,9 @@
 // REQUIRES: x86-registered-target
 
-// RUN: env OMVLL_CONFIG=%S/report_diff.py clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck %s
+// RUN: env OMVLL_CONFIG=%S/report_diff.py clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null -DNEEDS_OBFUSCATION | FileCheck %s
+// RUN: env OMVLL_CONFIG=%S/report_diff.py clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=NO_REPORT %s
 
+// Make sure the report_diff function was called if the obfuscation was applied
 // CHECK: omvll::Arithmetic applied obfuscation
 // CHECK: --- original
 // CHECK: +++ obfuscated
@@ -9,9 +11,13 @@
 // CHECK: -
 // CHECK: +
 
-void memcpy_xor(char *dst, const char *src, unsigned len) {
-  for (unsigned i = 0; i < len; i += 1) {
-    dst[i] = src[i] ^ 35;
-  }
-  dst[len] = '\0';
+// Make sure the report_diff function was NOT called if the obfuscation was NOT applied
+// NO_REPORT-NOT: omvll::Arithmetic applied obfuscation
+
+void test(char *dst, const char *src, unsigned len) {
+#if defined(NEEDS_OBFUSCATION)
+  *dst = *src ^ 35;
+#else
+  *dst = *src;
+#endif
 }

--- a/src/test/passes/arithmetic/report_diff-x86_64-linux.c
+++ b/src/test/passes/arithmetic/report_diff-x86_64-linux.c
@@ -5,81 +5,9 @@
 // CHECK: omvll::Arithmetic applied obfuscation
 // CHECK: --- original
 // CHECK: +++ obfuscated
-// CHECK: @@ -25,11 +25,11 @@
-// CHECK:    %12 = getelementptr inbounds i8, ptr %1, i64 %11
-// CHECK:    %13 = load i8, ptr %12, align 1, !tbaa !5
-// CHECK:    %14 = sext i8 %13 to i32
-// CHECK: -  %15 = xor i32 %14, 35
-// CHECK: +  %15 = call i32 @__omvll_mba(i32 %14, i32 35)
-// CHECK:    %16 = trunc i32 %15 to i8
-// CHECK:    %17 = getelementptr inbounds i8, ptr %0, i64 %11
-// CHECK:    store i8 %16, ptr %17, align 1, !tbaa !5
-// CHECK: -  %18 = add i32 %5, 1
-// CHECK: +  %18 = call i32 @__omvll_mba.1(i32 %5, i32 1)
-// CHECK:    br label %4, !llvm.loop !8
-// CHECK:  }
-//
-// CHECK: @@ -39,8 +39,60 @@
-// CHECK:  ; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-// CHECK:  declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
-//
-// CHECK: +; Function Attrs: alwaysinline optnone
-// CHECK: +define private i32 @__omvll_mba(i32 %0, i32 %1) #2 {
-// CHECK: +  %3 = add i32 %0, %1
-// CHECK: +  %4 = add i32 %3, 1
-// CHECK: +  %5 = xor i32 %0, -1
-// CHECK: +  %6 = xor i32 %1, -1
-// CHECK: +  %7 = or i32 %5, %6
-// CHECK: +  %8 = add i32 %4, %7
-// CHECK: +  %9 = or i32 %0, %1
-// CHECK: +  %10 = add i32 %0, %1
-// CHECK: +  %11 = or i32 %0, %1
-// CHECK: +  %12 = sub i32 %10, %11
-// CHECK: +  %13 = and i32 %0, %1
-// CHECK: +  %14 = sub i32 0, %12
-// CHECK: +  %15 = xor i32 %8, %14
-// CHECK: +  %16 = sub i32 0, %12
-// CHECK: +  %17 = and i32 %8, %16
-// CHECK: +  %18 = mul i32 2, %17
-// CHECK: +  %19 = add i32 %15, %18
-// CHECK: +  %20 = sub i32 %8, %12
-// CHECK: +  %21 = or i32 %0, %1
-// CHECK: +  %22 = and i32 %0, %1
-// CHECK: +  %23 = sub i32 %21, %22
-// CHECK: +  %24 = xor i32 %0, %1
-// CHECK: +  ret i32 %19
-// CHECK: +}
+// CHECK: @@
+// CHECK: -
 // CHECK: +
-// CHECK: +; Function Attrs: alwaysinline optnone
-// CHECK: +define private i32 @__omvll_mba.1(i32 %0, i32 %1) #2 {
-// CHECK: +  %3 = add i32 %0, %1
-// CHECK: +  %4 = or i32 %0, %1
-// CHECK: +  %5 = sub i32 %3, %4
-// CHECK: +  %6 = and i32 %0, %1
-// CHECK: +  %7 = add i32 %0, %1
-// CHECK: +  %8 = add i32 %7, 1
-// CHECK: +  %9 = xor i32 %0, -1
-// CHECK: +  %10 = xor i32 %1, -1
-// CHECK: +  %11 = or i32 %9, %10
-// CHECK: +  %12 = add i32 %8, %11
-// CHECK: +  %13 = or i32 %0, %1
-// CHECK: +  %14 = and i32 %5, %12
-// CHECK: +  %15 = or i32 %5, %12
-// CHECK: +  %16 = add i32 %14, %15
-// CHECK: +  %17 = add i32 %5, %12
-// CHECK: +  %18 = and i32 %0, %1
-// CHECK: +  %19 = or i32 %0, %1
-// CHECK: +  %20 = add i32 %18, %19
-// CHECK: +  %21 = add i32 %0, %1
-// CHECK: +  ret i32 %16
-// CHECK: +}
-// CHECK: +
-// CHECK:  attributes #0 = { nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:  attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-// CHECK: +attributes #2 = { alwaysinline optnone }
-//
-// CHECK:  !llvm.module.flags = !{!0, !1, !2, !3}
-// CHECK:  !llvm.ident = !{!4}
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/arithmetic/report_diff-x86_64-linux.c
+++ b/src/test/passes/arithmetic/report_diff-x86_64-linux.c
@@ -1,0 +1,89 @@
+// REQUIRES: x86-registered-target
+
+// RUN: env OMVLL_CONFIG=%S/report_diff.py clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck %s
+
+// CHECK: omvll::Arithmetic applied obfuscation
+// CHECK: --- original
+// CHECK: +++ obfuscated
+// CHECK: @@ -25,11 +25,11 @@
+// CHECK:    %12 = getelementptr inbounds i8, ptr %1, i64 %11
+// CHECK:    %13 = load i8, ptr %12, align 1, !tbaa !5
+// CHECK:    %14 = sext i8 %13 to i32
+// CHECK: -  %15 = xor i32 %14, 35
+// CHECK: +  %15 = call i32 @__omvll_mba(i32 %14, i32 35)
+// CHECK:    %16 = trunc i32 %15 to i8
+// CHECK:    %17 = getelementptr inbounds i8, ptr %0, i64 %11
+// CHECK:    store i8 %16, ptr %17, align 1, !tbaa !5
+// CHECK: -  %18 = add i32 %5, 1
+// CHECK: +  %18 = call i32 @__omvll_mba.1(i32 %5, i32 1)
+// CHECK:    br label %4, !llvm.loop !8
+// CHECK:  }
+//
+// CHECK: @@ -39,8 +39,60 @@
+// CHECK:  ; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:  declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
+//
+// CHECK: +; Function Attrs: alwaysinline optnone
+// CHECK: +define private i32 @__omvll_mba(i32 %0, i32 %1) #2 {
+// CHECK: +  %3 = add i32 %0, %1
+// CHECK: +  %4 = add i32 %3, 1
+// CHECK: +  %5 = xor i32 %0, -1
+// CHECK: +  %6 = xor i32 %1, -1
+// CHECK: +  %7 = or i32 %5, %6
+// CHECK: +  %8 = add i32 %4, %7
+// CHECK: +  %9 = or i32 %0, %1
+// CHECK: +  %10 = add i32 %0, %1
+// CHECK: +  %11 = or i32 %0, %1
+// CHECK: +  %12 = sub i32 %10, %11
+// CHECK: +  %13 = and i32 %0, %1
+// CHECK: +  %14 = sub i32 0, %12
+// CHECK: +  %15 = xor i32 %8, %14
+// CHECK: +  %16 = sub i32 0, %12
+// CHECK: +  %17 = and i32 %8, %16
+// CHECK: +  %18 = mul i32 2, %17
+// CHECK: +  %19 = add i32 %15, %18
+// CHECK: +  %20 = sub i32 %8, %12
+// CHECK: +  %21 = or i32 %0, %1
+// CHECK: +  %22 = and i32 %0, %1
+// CHECK: +  %23 = sub i32 %21, %22
+// CHECK: +  %24 = xor i32 %0, %1
+// CHECK: +  ret i32 %19
+// CHECK: +}
+// CHECK: +
+// CHECK: +; Function Attrs: alwaysinline optnone
+// CHECK: +define private i32 @__omvll_mba.1(i32 %0, i32 %1) #2 {
+// CHECK: +  %3 = add i32 %0, %1
+// CHECK: +  %4 = or i32 %0, %1
+// CHECK: +  %5 = sub i32 %3, %4
+// CHECK: +  %6 = and i32 %0, %1
+// CHECK: +  %7 = add i32 %0, %1
+// CHECK: +  %8 = add i32 %7, 1
+// CHECK: +  %9 = xor i32 %0, -1
+// CHECK: +  %10 = xor i32 %1, -1
+// CHECK: +  %11 = or i32 %9, %10
+// CHECK: +  %12 = add i32 %8, %11
+// CHECK: +  %13 = or i32 %0, %1
+// CHECK: +  %14 = and i32 %5, %12
+// CHECK: +  %15 = or i32 %5, %12
+// CHECK: +  %16 = add i32 %14, %15
+// CHECK: +  %17 = add i32 %5, %12
+// CHECK: +  %18 = and i32 %0, %1
+// CHECK: +  %19 = or i32 %0, %1
+// CHECK: +  %20 = add i32 %18, %19
+// CHECK: +  %21 = add i32 %0, %1
+// CHECK: +  ret i32 %16
+// CHECK: +}
+// CHECK: +
+// CHECK:  attributes #0 = { nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:  attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK: +attributes #2 = { alwaysinline optnone }
+//
+// CHECK:  !llvm.module.flags = !{!0, !1, !2, !3}
+// CHECK:  !llvm.ident = !{!4}
+
+void memcpy_xor(char *dst, const char *src, unsigned len) {
+  for (unsigned i = 0; i < len; i += 1) {
+    dst[i] = src[i] ^ 35;
+  }
+  dst[len] = '\0';
+}

--- a/src/test/passes/arithmetic/report_diff.py
+++ b/src/test/passes/arithmetic/report_diff.py
@@ -1,0 +1,20 @@
+import omvll
+from difflib import unified_diff
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2)
+    def report_diff(self, pass_name: str, original: str, obfuscated: str):
+        print(pass_name, "applied obfuscation:")
+        diff = unified_diff(original.splitlines(), obfuscated.splitlines(),
+                            'original', 'obfuscated', lineterm='')
+        for line in diff:
+            print(line)
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()


### PR DESCRIPTION
Extend the Python API in a way that allows users to monitor IR-level changes from individual passes. That might be useful for experimentation, validation, testing, etc. The included test shows how to configure it.