### PR TITLE
Rework `StringEncOptStack` option to use globals

### DIFF
--- a/src/include/omvll/passes/string-encoding/StringEncoding.hpp
+++ b/src/include/omvll/passes/string-encoding/StringEncoding.hpp
@@ -57,38 +57,35 @@ struct StringEncoding : llvm::PassInfoMixin<StringEncoding> {
                               llvm::ModuleAnalysisManager &MAM);
   static bool isRequired() { return true; }
 
-  bool runOnBasicBlock(llvm::Module &M, llvm::Function &F, llvm::BasicBlock &BB,
-                       ObfuscationConfig &UserConfig);
-
-  bool injectDecoding(llvm::BasicBlock &BB, llvm::Instruction &I, llvm::Use &Op,
+  bool encodeStrings(llvm::Function &F, ObfuscationConfig &UserConfig);
+  bool injectDecoding(llvm::Instruction &I, llvm::Use &Op,
                       llvm::GlobalVariable &G,
                       llvm::ConstantDataSequential &Data,
                       const EncodingInfo &Info);
-  bool injectOnStack(llvm::BasicBlock &BB, llvm::Instruction &I, llvm::Use &Op,
+  bool injectOnStack(llvm::Instruction &I, llvm::Use &Op,
                      llvm::GlobalVariable &G,
                      llvm::ConstantDataSequential &Data,
                      const EncodingInfo &Info);
-  bool injectOnStackLoop(llvm::BasicBlock &BB, llvm::Instruction &I,
-                         llvm::Use &Op, llvm::GlobalVariable &G,
+  bool injectOnStackLoop(llvm::Instruction &I, llvm::Use &Op,
+                         llvm::GlobalVariable &G,
                          llvm::ConstantDataSequential &Data,
                          const EncodingInfo &Info);
-  bool process(llvm::BasicBlock &BB, llvm::Instruction &I, llvm::Use &Op,
-               llvm::GlobalVariable &G, llvm::ConstantDataSequential &Data,
-               StringEncodingOpt &Opt);
-  bool processReplace(llvm::BasicBlock &BB, llvm::Instruction &I, llvm::Use &Op,
+  bool process(llvm::Instruction &I, llvm::Use &Op, llvm::GlobalVariable &G,
+               llvm::ConstantDataSequential &Data, StringEncodingOpt &Opt);
+  bool processReplace(llvm::Instruction &I, llvm::Use &Op,
                       llvm::GlobalVariable &G,
                       llvm::ConstantDataSequential &Data,
                       StringEncOptReplace &Rep);
-  bool processGlobal(llvm::BasicBlock &BB, llvm::Instruction &I, llvm::Use &Op,
+  bool processGlobal(llvm::Instruction &I, llvm::Use &Op,
                      llvm::GlobalVariable &G,
                      llvm::ConstantDataSequential &Data,
                      StringEncOptGlobal &Global);
-  bool processOnStack(llvm::BasicBlock &BB, llvm::Instruction &I, llvm::Use &Op,
+  bool processOnStack(llvm::Instruction &I, llvm::Use &Op,
                       llvm::GlobalVariable &G,
                       llvm::ConstantDataSequential &Data,
                       const StringEncOptStack &Stack);
-  bool processOnStackLoop(llvm::BasicBlock &BB, llvm::Instruction &I,
-                          llvm::Use &Op, llvm::GlobalVariable &G,
+  bool processOnStackLoop(llvm::Instruction &I, llvm::Use &Op,
+                          llvm::GlobalVariable &G,
                           llvm::ConstantDataSequential &Data);
 
   inline EncodingInfo *getEncoding(const llvm::GlobalVariable &GV) {

--- a/src/test/passes/arithmetic/xor-arm-android.c
+++ b/src/test/passes/arithmetic/xor-arm-android.c
@@ -1,3 +1,8 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
 // REQUIRES: arm-registered-target
 
 // RUN:                                        clang -target arm-linux-android                         -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=R0 %s

--- a/src/test/passes/cfg-flattening/basic-arm-android.c
+++ b/src/test/passes/cfg-flattening/basic-arm-android.c
@@ -1,3 +1,8 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
 // REQUIRES: arm-registered-target
 
 // RUN:                                   clang -target arm-linux-android                         -O1 -fno-verbose-asm -S %s -o - | FileCheck --check-prefix=NO-FLAT %s

--- a/src/test/passes/string-encoding/basic-aarch64-stackopt.ll
+++ b/src/test/passes/string-encoding/basic-aarch64-stackopt.ll
@@ -1,0 +1,33 @@
+;
+; This file is distributed under the Apache License v2.0. See LICENSE for details.
+;
+
+; REQUIRES: aarch64-registered-target
+
+;     RUN: env OMVLL_CONFIG=%S/config_replace.py clang++ -fpass-plugin=%libOMVLL \
+;     RUN:         -target arm64-apple-ios17.5.0 -S -emit-llvm -O0 -c %s -o - | FileCheck %s
+;
+;     RUN: env OMVLL_CONFIG=%S/config_replace.py clang++ -fpass-plugin=%libOMVLL \
+;     RUN:         -target aarch64-linux-android -S -emit-llvm -O0 -c %s -o - | FileCheck %s
+;
+;     CHECK-NOT:     {{.*Hello, Stack.*}}
+
+@__const.main.Hello = private constant [13 x i8] c"Hello, Stack\00", align 1
+
+define void @test() {
+; CHECK-LABEL: @test(
+; CHECK:         %5 = getelementptr inbounds [13 x i8], ptr @0, i64 0, i64 0
+; CHECK-NEXT:    %6 = load i1, ptr @1, align 1
+; CHECK-NEXT:    %7 = icmp eq i1 %6, false
+; CHECK-NEXT:    br i1 %7, label %8, label %__omvll_decode_wrap.exit
+; CHECK:       8:
+; CHECK-NEXT:    call void @__omvll_decode(ptr %5, ptr @__const.main.Hello, i64 %3, i32 %4)
+; CHECK-NEXT:    store i1 true, ptr @1, align 1
+; CHECK-NEXT:    br label %__omvll_decode_wrap.exit
+; CHECK:       __omvll_decode_wrap.exit:
+; CHECK-NEXT:    %puts = call i32 @puts(ptr %5)
+  %puts = call i32 @puts(ptr @__const.main.Hello)
+  ret void
+}
+
+declare i32 @puts(ptr)

--- a/src/test/passes/string-encoding/basic-aarch64.cpp
+++ b/src/test/passes/string-encoding/basic-aarch64.cpp
@@ -6,7 +6,7 @@
 // REQUIRES: aarch64-registered-target
 
 // The default object contains the file-name string:
-//     RUN: clang++ -target aarch64-linux-android-O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
+//     RUN: clang++ -target aarch64-linux-android -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
 //     RUN: clang++ -target arm64-apple-ios17.5.0 -O1 -c %s -o - | strings | FileCheck --check-prefix=CHECK-DEFAULT  -DFILE_NAME=%s %s
 //     CHECK-DEFAULT: [[FILE_NAME]]
 

--- a/src/test/passes/string-encoding/basic-arm-android.cpp
+++ b/src/test/passes/string-encoding/basic-arm-android.cpp
@@ -1,3 +1,8 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
 // REQUIRES: arm-registered-target
 
 // The default object contains the file-name string:

--- a/src/test/passes/string-encoding/config_replace.py
+++ b/src/test/passes/string-encoding/config_replace.py
@@ -15,6 +15,8 @@ class MyConfig(omvll.ObfuscationConfig):
             return omvll.StringEncOptGlobal()
         if string.endswith(b"Swift"):
             return omvll.StringEncOptStack()
+        if string.endswith(b"Stack"):
+            return omvll.StringEncOptStack()
 
 @lru_cache(maxsize=1)
 def omvll_get_config() -> omvll.ObfuscationConfig:


### PR DESCRIPTION
We should never desire to have the decoded string variable live in a stack-allocated variable; as literals must remain valid throughout the lifetime of the application. This poses the question of why not using `StringEncOptGlobal` option in the first place. Leveraging `StringEncOptStack` option allows the strings to be decoded lazily; whereas, using `StringEncOptGlobal` as a default option would come to the detriment of performance, since all the strings are decoded at load-time. Hence, decode the string in a global variable locally within the function, and do not decode it twice, if it has already been decoded.
Minor opportunity to clean up things here and there too.