### PR TITLE
Enable global configuration to exclude modules and functions

### DIFF
--- a/src/core/omvll_config.cpp
+++ b/src/core/omvll_config.cpp
@@ -29,6 +29,8 @@ void initDefaultConfig() {
   Config.Cleaning = true;
   Config.InlineJniWrappers = true;
   Config.ShuffleFunctions = true;
+  Config.GlobalModuleExclude.clear();
+  Config.GlobalFunctionExclude.clear();
 }
 
 } // end namespace omvll

--- a/src/core/python/PyConfig.cpp
+++ b/src/core/python/PyConfig.cpp
@@ -118,6 +118,24 @@ void OMVLLCtor(py::module_ &m) {
                         sub_AF34() // say_hi
 
                     If this value is set to ``True`` (which is the default value), the sequence is randomized.
+                    )delim")
+
+      .def_readwrite("global_mod_exclude", &OMVLLConfig::GlobalModuleExclude,
+                     R"delim(
+                    This attribute is a list of strings used to exclude entire modules from obfuscation.
+                    Each entry in the list can be a partial or full match of the module's name.
+                    For example, if a module's name is `a/b/c/d.cpp`, it can be excluded by including `"b/"` in the list.
+                    When a module is excluded, none of the obfuscation passes will be applied to it.
+                    
+                    By default, this list is empty.
+                    )delim")
+
+      .def_readwrite("global_func_exclude", &OMVLLConfig::GlobalFunctionExclude,
+                     R"delim(
+                    This attribute is a list of strings used to exclude specific functions from obfuscation.
+                    When a function is excluded, none of the obfuscation passes will be applied to it.
+                    
+                    By default, this list is empty.
                     )delim");
 
   m.attr("config") = &Config;

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -27,6 +27,7 @@
 #include "omvll/ObfuscationConfig.hpp"
 #include "omvll/PyConfig.hpp"
 #include "omvll/log.hpp"
+#include "omvll/omvll_config.hpp"
 #include "omvll/utils.hpp"
 
 using namespace llvm;
@@ -466,6 +467,19 @@ PreservedAnalyses IRChangesMonitor::report() {
   }
 
   return ChangeReported ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}
+
+bool isModuleExcluded(Module *M) {
+  auto Begin = Config.GlobalModuleExclude.begin();
+  auto End = Config.GlobalModuleExclude.end();
+  auto It = std::find_if(Begin, End, [&](const auto &ExcludedModule) {
+    return M->getName().contains(ExcludedModule);
+  });
+  return It != End;
+}
+
+bool isFunctionExcluded(Function *F) {
+  return is_contained(Config.GlobalFunctionExclude, F->getName());
 }
 
 } // end namespace omvll

--- a/src/include/omvll/omvll_config.hpp
+++ b/src/include/omvll/omvll_config.hpp
@@ -15,6 +15,8 @@ struct OMVLLConfig {
   bool Cleaning;
   bool ShuffleFunctions;
   bool InlineJniWrappers;
+  std::vector<std::string> GlobalModuleExclude;
+  std::vector<std::string> GlobalFunctionExclude;
 };
 
 // Defined in omvll_config.cpp.

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -46,6 +46,8 @@ size_t demoteRegs(llvm::Function &F);
 size_t reg2mem(llvm::Function &F);
 
 void shuffleFunctions(llvm::Module &M);
+bool isModuleExcluded(llvm::Module *M);
+bool isFunctionExcluded(llvm::Function *F);
 
 [[noreturn]] void fatalError(const char *Msg);
 [[noreturn]] void fatalError(const std::string &Msg);

--- a/src/passes/anti-hook/AntiHook.cpp
+++ b/src/passes/anti-hook/AntiHook.cpp
@@ -74,6 +74,11 @@ bool AntiHook::runOnFunction(Function &F) {
 }
 
 PreservedAnalyses AntiHook::run(Module &M, ModuleAnalysisManager &FAM) {
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   bool Changed = false;
   PyConfig &Config = PyConfig::instance();
   SINFO("[{}] Executing on module {}", name(), M.getName());
@@ -81,7 +86,8 @@ PreservedAnalyses AntiHook::run(Module &M, ModuleAnalysisManager &FAM) {
   RNG = M.createRNG(name());
 
   for (Function &F : M) {
-    if (!Config.getUserConfig()->antiHooking(F.getParent(), &F))
+    if (isFunctionExcluded(&F) ||
+        !Config.getUserConfig()->antiHooking(F.getParent(), &F))
       continue;
 
     Changed |= runOnFunction(F);

--- a/src/passes/arithmetic/Arithmetic.cpp
+++ b/src/passes/arithmetic/Arithmetic.cpp
@@ -221,6 +221,11 @@ bool Arithmetic::runOnBasicBlock(BasicBlock &BB) {
 }
 
 PreservedAnalyses Arithmetic::run(Module &M, ModuleAnalysisManager &FAM) {
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   bool Changed = false;
   PyConfig &Config = PyConfig::instance();
   SINFO("[{}] Executing on module {}", name(), M.getName());
@@ -236,6 +241,9 @@ PreservedAnalyses Arithmetic::run(Module &M, ModuleAnalysisManager &FAM) {
                  std::back_inserter(ToVisit), [](auto &F) { return &F; });
 
   for (Function *F : ToVisit) {
+    if (isFunctionExcluded(F))
+      continue;
+
     ArithmeticOpt Opt = Config.getUserConfig()->obfuscateArithmetics(&M, F);
     if (!Opt)
       continue;

--- a/src/passes/break-cfg/BreakControlFlow.cpp
+++ b/src/passes/break-cfg/BreakControlFlow.cpp
@@ -207,6 +207,11 @@ bool BreakControlFlow::runOnFunction(Function &F) {
 }
 
 PreservedAnalyses BreakControlFlow::run(Module &M, ModuleAnalysisManager &FAM) {
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   bool Changed = false;
   PyConfig &Config = PyConfig::instance();
   SINFO("[{}] Executing on module {}", name(), M.getName());
@@ -214,7 +219,7 @@ PreservedAnalyses BreakControlFlow::run(Module &M, ModuleAnalysisManager &FAM) {
   JIT = std::make_unique<Jitter>(M.getTargetTriple());
 
   for (Function &F : M) {
-    if (F.isDeclaration() || F.isIntrinsic())
+    if (isFunctionExcluded(&F) || F.isDeclaration() || F.isIntrinsic())
       continue;
 
     if (Config.getUserConfig()->breakControlFlow(&M, &F))

--- a/src/passes/cfg-flattening/ControlFlowFlattening.cpp
+++ b/src/passes/cfg-flattening/ControlFlowFlattening.cpp
@@ -464,12 +464,18 @@ bool ControlFlowFlattening::runOnFunction(Function &F,
 PreservedAnalyses ControlFlowFlattening::run(Module &M,
                                              ModuleAnalysisManager &MAM) {
   bool Changed = false;
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   PyConfig &Config = PyConfig::instance();
   SINFO("[{}] Executing on module {}", name(), M.getName());
   std::unique_ptr<RandomNumberGenerator> RNG = M.createRNG(name());
 
   for (Function &F : M) {
-    if (!Config.getUserConfig()->controlFlowGraphFlattening(&M, &F))
+    if (isFunctionExcluded(&F) ||
+        !Config.getUserConfig()->controlFlowGraphFlattening(&M, &F))
       continue;
 
     bool MadeChange = runOnFunction(F, *RNG);

--- a/src/passes/cleaning/Cleaning.cpp
+++ b/src/passes/cleaning/Cleaning.cpp
@@ -18,10 +18,18 @@ PreservedAnalyses Cleaning::run(Module &M, ModuleAnalysisManager &FAM) {
   if (!Config.Cleaning)
     return PreservedAnalyses::all();
 
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   bool Changed = false;
   SINFO("[{}] Executing on module {}", name(), M.getName());
 
   for (Function &F : M) {
+    if (isFunctionExcluded(&F))
+      continue;
+
     std::string Name  = demangle(F.getName().str());
     StringRef NRef = Name;
     if (NRef.startswith("_JNIEnv::") && Config.InlineJniWrappers) {

--- a/src/passes/objc-cleaner/ObjCleaner.cpp
+++ b/src/passes/objc-cleaner/ObjCleaner.cpp
@@ -26,6 +26,11 @@ inline bool isObjCVar(const GlobalVariable &G) {
 
 PreservedAnalyses ObjCleaner::run(Module &M, ModuleAnalysisManager &FAM) {
   bool Changed = false;
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   SINFO("[{}] Executing on module {}", name(), M.getName());
 
   for (GlobalVariable &G : M.globals()) {

--- a/src/passes/opaque-constants/OpaqueConstants.cpp
+++ b/src/passes/opaque-constants/OpaqueConstants.cpp
@@ -247,6 +247,11 @@ bool OpaqueConstants::runOnBasicBlock(llvm::BasicBlock &BB,
 
 PreservedAnalyses OpaqueConstants::run(Module &M, ModuleAnalysisManager &FAM) {
   bool Changed = false;
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   PyConfig &Config = PyConfig::instance();
   SINFO("[{}] Executing on module {}", name(), M.getName());
   RNG = M.createRNG(name());
@@ -259,6 +264,9 @@ PreservedAnalyses OpaqueConstants::run(Module &M, ModuleAnalysisManager &FAM) {
   });
 
   for (Function &F : M) {
+    if (isFunctionExcluded(&F))
+      continue;
+
     OpaqueConstantsOpt Opt = Config.getUserConfig()->obfuscateConstants(&M, &F);
     OpaqueConstantsOpt *Inserted = nullptr;
     if (isSkip(Opt))

--- a/src/passes/opaque-field-access/OpaqueFieldAccess.cpp
+++ b/src/passes/opaque-field-access/OpaqueFieldAccess.cpp
@@ -379,10 +379,19 @@ bool OpaqueFieldAccess::runOnBasicBlock(BasicBlock &BB) {
 
 PreservedAnalyses OpaqueFieldAccess::run(Module &M,
                                          ModuleAnalysisManager &FAM) {
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   bool Changed = false;
-  for (Function &F : M)
+  for (Function &F : M) {
+    if (isFunctionExcluded(&F))
+      continue;
+
     for (BasicBlock &BB : F)
       Changed |= runOnBasicBlock(BB);
+  }
 
   SINFO("[{}] Changes {} applied on module {}", name(), Changed ? "" : "not",
         M.getName());

--- a/src/passes/string-encoding/StringEncoding.cpp
+++ b/src/passes/string-encoding/StringEncoding.cpp
@@ -349,6 +349,11 @@ bool StringEncoding::encodeStrings(Function &F, ObfuscationConfig &UserConfig) {
 }
 
 PreservedAnalyses StringEncoding::run(Module &M, ModuleAnalysisManager &MAM) {
+  if (isModuleExcluded(&M)) {
+    SINFO("Excluding module [{}]", M.getName());
+    return PreservedAnalyses::all();
+  }
+
   bool Changed = false;
   SINFO("[{}] Executing on module {}", name(), M.getName());
   auto &Config = PyConfig::instance();
@@ -357,7 +362,7 @@ PreservedAnalyses StringEncoding::run(Module &M, ModuleAnalysisManager &MAM) {
 
   std::vector<Function *> ToVisit;
   for (Function &F : M) {
-    if (F.empty() || F.isDeclaration())
+    if (isFunctionExcluded(&F) || F.empty() || F.isDeclaration())
       continue;
 
     demotePHINode(F);

--- a/src/test/passes/arithmetic/arithmetic-global-exclude-x86_64-linux.c
+++ b/src/test/passes/arithmetic/arithmetic-global-exclude-x86_64-linux.c
@@ -1,0 +1,19 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+// REQUIRES: x86-registered-target
+
+// RUN: env OMVLL_CONFIG=%S/config_exclude_module.py   clang -target x86_64-pc-linux-gnu  -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=CHECK %s
+// RUN: env OMVLL_CONFIG=%S/config_exclude_function.py clang -target x86_64-pc-linux-gnu  -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=CHECK %s
+
+// Make sure the obfuscate arithmetic function was NOT called
+// CHECK-NOT: obfuscate_arithmetic is called
+
+void memcpy_xor(char *dst, const char *src, unsigned len) {
+  for (unsigned i = 0; i < len; i += 1) {
+    dst[i] = src[i] ^ 35;
+  }
+  dst[len] = '\0';
+}

--- a/src/test/passes/arithmetic/config_exclude_function.py
+++ b/src/test/passes/arithmetic/config_exclude_function.py
@@ -1,0 +1,22 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    excluded_function_value = "memcpy_xor"
+    omvll.config.global_func_exclude = [excluded_function_value]
+
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        if (fun.name == self.excluded_function_value):
+            print("obfuscate_arithmetic is called")
+        return omvll.ArithmeticOpt(rounds=2)
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/config_exclude_module.py
+++ b/src/test/passes/arithmetic/config_exclude_module.py
@@ -1,0 +1,20 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    omvll.config.global_mod_exclude = ["global-exclude-"]
+
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        print("obfuscate_arithmetic is called")
+        return omvll.ArithmeticOpt(rounds=2)
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/cfg-flattening/cfg-flattening-global-exclude-x86_64-linux.c
+++ b/src/test/passes/cfg-flattening/cfg-flattening-global-exclude-x86_64-linux.c
@@ -1,0 +1,27 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+// REQUIRES: x86-registered-target
+
+// RUN: env OMVLL_CONFIG=%S/config_exclude_module.py   clang -target x86_64-pc-linux-gnu  -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=CHECK %s
+// RUN: env OMVLL_CONFIG=%S/config_exclude_function.py clang -target x86_64-pc-linux-gnu  -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=CHECK %s
+
+// Make sure the function is not flattened.
+// CHECK-NOT: flatten_cfg is called
+
+int check_password(const char *passwd) {
+  if (passwd[0] == 'r') {
+    if (passwd[1] == 'i') {
+      if (passwd[2] == 'g') {
+        if (passwd[3] == 'h') {
+          if (passwd[4] == 't') {
+            return 0;
+          }
+        }
+      }
+    }
+  }
+  return 1;
+}

--- a/src/test/passes/cfg-flattening/config_exclude_function.py
+++ b/src/test/passes/cfg-flattening/config_exclude_function.py
@@ -1,0 +1,22 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from difflib import unified_diff
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    excluded_function_value = "check_password"
+    omvll.config.global_func_exclude = [excluded_function_value]
+
+    def __init__(self):
+        super().__init__()
+    def flatten_cfg(self, mod: omvll.Module, func: omvll.Function):
+        if (func.name == self.excluded_function_value):
+             print("flatten_cfg is called")
+        return True
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/cfg-flattening/config_exclude_module.py
+++ b/src/test/passes/cfg-flattening/config_exclude_module.py
@@ -1,0 +1,19 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    omvll.config.global_mod_exclude = ["global-exclude-"]
+
+    def __init__(self):
+        super().__init__()
+    def flatten_cfg(self, mod: omvll.Module, func: omvll.Function):
+        print("cfg-flattening is called")
+        return True
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/string-encoding/config_exclude_function.py
+++ b/src/test/passes/string-encoding/config_exclude_function.py
@@ -1,0 +1,21 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    excluded_function_value = "check_code"
+    omvll.config.global_func_exclude = [excluded_function_value]
+
+    def __init__(self):
+        super().__init__()
+    def obfuscate_string(self, _, __, string: bytes):
+        if string.endswith(b"ObfuscateMe"):
+            print("string-encoding is called")
+            return omvll.StringEncOptGlobal()
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/string-encoding/config_exclude_module.py
+++ b/src/test/passes/string-encoding/config_exclude_module.py
@@ -1,0 +1,19 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    omvll.config.global_mod_exclude = ["global-exclude-"]
+
+    def __init__(self):
+        super().__init__()
+    def obfuscate_string(self, _, __, string: bytes):
+        print("obfuscate_string is called")
+        return omvll.StringEncOptGlobal()
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/string-encoding/string-encoding-global-exclude-x86_64-linux.c
+++ b/src/test/passes/string-encoding/string-encoding-global-exclude-x86_64-linux.c
@@ -1,0 +1,19 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+// REQUIRES: x86-registered-target
+
+// RUN: env OMVLL_CONFIG=%S/config_exclude_module.py   clang -target x86_64-pc-linux-gnu  -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=CHECK %s
+// RUN: env OMVLL_CONFIG=%S/config_exclude_function.py clang -target x86_64-pc-linux-gnu  -fpass-plugin=%libOMVLL -O1 -S %s -o /dev/null | FileCheck --allow-empty --check-prefix=CHECK %s
+
+// Make sure the string is not encoded.
+// CHECK-NOT: obfuscate_string is called
+
+void check_code(int code) {
+  char *myString = "ObfuscateMe";
+  if (myString[0] == 'O') {
+    myString[0] = 'N';
+  }
+}


### PR DESCRIPTION
Simplify configuration with global excludes, it is helpful for third party libraries included on your project