### PR TITLE
Add default behaviour helper to be invoked from Python config

### DIFF
--- a/src/core/omvll_config.cpp
+++ b/src/core/omvll_config.cpp
@@ -31,6 +31,7 @@ void initDefaultConfig() {
   Config.ShuffleFunctions = true;
   Config.GlobalModuleExclude.clear();
   Config.GlobalFunctionExclude.clear();
+  Config.ProbabilitySeed = 1;
 }
 
 } // end namespace omvll

--- a/src/core/python/PyConfig.cpp
+++ b/src/core/python/PyConfig.cpp
@@ -136,6 +136,15 @@ void OMVLLCtor(py::module_ &m) {
                     When a function is excluded, none of the obfuscation passes will be applied to it.
                     
                     By default, this list is empty.
+                    )delim")
+
+      .def_readwrite("probability_seed", &OMVLLConfig::ProbabilitySeed,
+                     R"delim(
+                    probability_seed is a configurable value used to initialize the random number generator.
+                    Whenever a random value is required during the obfuscation process,
+                    the generator will use this predefined seed to ensure deterministic and reproducible randomness.
+
+                    The default value is 1.
                     )delim");
 
   m.attr("config") = &Config;
@@ -324,7 +333,11 @@ void OMVLLCtor(py::module_ &m) {
            R"delim(
          User-callback to monitor IR-level changes from individual obfuscation passes.
          )delim",
-           "pass_name"_a, "original"_a, "obfuscated"_a);
+           "pass_name"_a, "original"_a, "obfuscated"_a)
+
+      .def("default_config", &ObfuscationConfig::defaultConfig, "module"_a,
+           "function"_a, "ModuleExcludes"_a, "FunctionExcludes"_a,
+           "FunctionIncludes"_a, "Probability"_a);
 }
 
 std::unique_ptr<py::module_> initOMVLLCore(py::dict Modules) {

--- a/src/core/python/PyObfuscationConfig.hpp
+++ b/src/core/python/PyObfuscationConfig.hpp
@@ -37,6 +37,12 @@ class PyObfuscationConfig : public ObfuscationConfig {
   OpaqueConstantsOpt obfuscateConstants(llvm::Module *M,
                                         llvm::Function *F) override;
 
+  bool defaultConfig(llvm::Module *M, llvm::Function *F,
+                     const std::vector<std::string> &ModuleExcludes = {},
+                     const std::vector<std::string> &FunctionExcludes = {},
+                     const std::vector<std::string> &FunctionIncludes = {},
+                     int Probability = 0) override;
+
   bool hasReportDiffOverride() override;
   void reportDiff(const std::string &Pass, const std::string &Original,
                   const std::string &Obfuscated) override;

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -482,4 +482,23 @@ bool isFunctionExcluded(Function *F) {
   return is_contained(Config.GlobalFunctionExclude, F->getName());
 }
 
+// Default value is false.
+bool RandomGenerator::Seeded = false;
+
+int RandomGenerator::generate() {
+  if (!RandomGenerator::Seeded) {
+    std::srand(Config.ProbabilitySeed);
+    RandomGenerator::Seeded = true;
+  }
+
+  // Generate number between 0 and 99.
+  return std::rand() % 100;
+}
+
+int RandomGenerator::checkProbability(int Target) {
+  if (RandomGenerator::generate() < Target)
+    return true;
+  return false;
+}
+
 } // end namespace omvll

--- a/src/include/omvll/ObfuscationConfig.hpp
+++ b/src/include/omvll/ObfuscationConfig.hpp
@@ -5,6 +5,9 @@
 // details.
 //
 
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+
 #include "omvll/passes/ObfuscationOpt.hpp"
 
 // Forward declarations
@@ -47,6 +50,12 @@ struct ObfuscationConfig {
                                              llvm::Function *F) = 0;
 
   virtual AntiHookOpt antiHooking(llvm::Module *M, llvm::Function *F) = 0;
+
+  virtual bool defaultConfig(llvm::Module *M, llvm::Function *F,
+                             const std::vector<std::string> &ModuleExcludes,
+                             const std::vector<std::string> &FunctionExcludes,
+                             const std::vector<std::string> &FunctionIncludes,
+                             int Probability) = 0;
 
   virtual bool hasReportDiffOverride() { return false; };
   virtual void reportDiff(const std::string &Pass, const std::string &Original,

--- a/src/include/omvll/omvll_config.hpp
+++ b/src/include/omvll/omvll_config.hpp
@@ -12,11 +12,12 @@ namespace omvll {
 
 struct OMVLLConfig {
   std::vector<std::string> Passes;
+  std::vector<std::string> GlobalModuleExclude;
+  std::vector<std::string> GlobalFunctionExclude;
   bool Cleaning;
   bool ShuffleFunctions;
   bool InlineJniWrappers;
-  std::vector<std::string> GlobalModuleExclude;
-  std::vector<std::string> GlobalFunctionExclude;
+  int ProbabilitySeed;
 };
 
 // Defined in omvll_config.cpp.

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -85,4 +85,13 @@ private:
   bool ChangeReported;
 };
 
+class RandomGenerator {
+private:
+  static bool Seeded;
+
+public:
+  static int generate();
+  static int checkProbability(int Target);
+};
+
 } // end namespace omvll

--- a/src/test/passes/arithmetic/config_defaultConfig_empty_params.py
+++ b/src/test/passes/arithmetic/config_defaultConfig_empty_params.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2) if omvll.ObfuscationConfig.default_config(self, mod, fun, [], [], [], 0) else False
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/config_defaultConfig_exclude_function.py
+++ b/src/test/passes/arithmetic/config_defaultConfig_exclude_function.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2) if  omvll.ObfuscationConfig.default_config(self, mod, fun, [], ["memcpy_xor"], [], 100) else False
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/config_defaultConfig_exclude_module.py
+++ b/src/test/passes/arithmetic/config_defaultConfig_exclude_module.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2) if omvll.ObfuscationConfig.default_config(self, mod, fun, ["default-config"], [], [], 100) else False
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/config_defaultConfig_include_function.py
+++ b/src/test/passes/arithmetic/config_defaultConfig_include_function.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2) if omvll.ObfuscationConfig.default_config(self, mod, fun, [], [], ["memcpy_xor"], 0) else False
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/config_defaultConfig_probability_0.py
+++ b/src/test/passes/arithmetic/config_defaultConfig_probability_0.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2) if omvll.ObfuscationConfig.default_config(self, mod, fun, [], [], [], 0) else False
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/config_defaultConfig_probability_100.py
+++ b/src/test/passes/arithmetic/config_defaultConfig_probability_100.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return omvll.ArithmeticOpt(rounds=2) if omvll.ObfuscationConfig.default_config(self, mod, fun, [], [], [], 100) else False
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/passes/arithmetic/default-config-x86_64-linux.c
+++ b/src/test/passes/arithmetic/default-config-x86_64-linux.c
@@ -1,0 +1,56 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+// REQUIRES: x86-registered-target
+
+// RUN:                                                                  clang -target x86_64-pc-linux-gnu                         -O1 -S %s -o - | FileCheck --check-prefix=DEFAULT %s
+// RUN: env OMVLL_CONFIG=%S/config_defaultConfig_empty_params.py         clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o - | FileCheck --check-prefix=DEFAULT %s
+// RUN: env OMVLL_CONFIG=%S/config_defaultConfig_include_function.py     clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o - | FileCheck --check-prefix=CHECK %s
+// RUN: env OMVLL_CONFIG=%S/config_defaultConfig_exclude_module.py       clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o - | FileCheck --check-prefix=DEFAULT %s
+// RUN: env OMVLL_CONFIG=%S/config_defaultConfig_exclude_function.py     clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o - | FileCheck --check-prefix=DEFAULT %s
+// RUN: env OMVLL_CONFIG=%S/config_defaultConfig_probability_0.py        clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o - | FileCheck --check-prefix=DEFAULT %s
+// RUN: env OMVLL_CONFIG=%S/config_defaultConfig_probability_100.py      clang -target x86_64-pc-linux-gnu -fpass-plugin=%libOMVLL -O1 -S %s -o - | FileCheck --check-prefix=CHECK %s
+
+// DEFAULT-LABEL: memcpy_xor:
+// DEFAULT:       .LBB0_2:
+// DEFAULT:           movzbl	(%rsi,%rcx), %edx
+// DEFAULT:           xorb	$35, %dl
+// DEFAULT:           movb	%dl, (%rdi,%rcx)
+// DEFAULT:           incq	%rcx
+// DEFAULT:           cmpq	%rcx, %rax
+// DEFAULT:           jne	.LBB0_2
+
+// CHECK-LABEL: memcpy_xor:
+// CHECK:       .LBB0_2:
+// CHECK:           movl	%eax, %ecx
+// CHECK:           movsbl	(%rsi,%rcx), %r8d
+// CHECK:           movl	%r8d, %r9d
+// CHECK:           notl	%r9d
+// CHECK:           orl	$-36, %r9d
+// CHECK:           addl	%r8d, %r9d
+// CHECK:           addl	$36, %r9d
+// CHECK:           andl	$35, %r8d
+// CHECK:           negl	%r8d
+// CHECK:           movl	%r9d, %r10d
+// CHECK:           xorl	%r8d, %r10d
+// CHECK:           andl	%r9d, %r8d
+// CHECK:           leal	(%r10,%r8,2), %r8d
+// CHECK:           movb	%r8b, (%rdi,%rcx)
+// CHECK:           movl	%eax, %ecx
+// CHECK:           notl	%ecx
+// CHECK:           orl	$-2, %ecx
+// CHECK:           addl	%eax, %ecx
+// CHECK:           andl	$1, %eax
+// CHECK:           addl	%ecx, %eax
+// CHECK:           addl	$2, %eax
+// CHECK:           cmpl	%edx, %eax
+// CHECK:           jb	.LBB0_2
+
+void memcpy_xor(char *dst, const char *src, unsigned len) {
+  for (unsigned i = 0; i < len; i += 1) {
+    dst[i] = src[i] ^ 35;
+  }
+  dst[len] = '\0';
+}


### PR DESCRIPTION
From config file you can call now:
self.default_behaviour(mod, func, list1, list2, list3)
or
self.default_behaviour(mod, func, list1, [], list3) // if list 2 is empty
or 
self.default_behaviour(mod, func, list1, list2) // if list 3 is empty and you don't want to put parameter 3
or 
self.default_behaviour(mod, func, list1) // if list 1 is the only one not empty

