### PR TITLE
Fix JIT error: no available targets are compatible

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,7 +149,6 @@ set(LLVM_LIBS_DEP
   demangle
   OrcJIT
   native
-
 )
 
 # Used for jitAsm in Jitter. Remove when we switch to calling the host compiler.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,10 +149,18 @@ set(LLVM_LIBS_DEP
   demangle
   OrcJIT
   native
-  ARMCodeGen
-  ARMAsmParser
-  AArch64CodeGen
-  AArch64AsmParser
+
+)
+
+# Used for jitAsm in Jitter. Remove when we switch to calling the host compiler.
+# See discussion: https://github.com/open-obfuscator/o-mvll/pull/78#pullrequestreview-2780108790
+list(APPEND LLVM_LIBS_DEP
+    ARMCodeGen
+    ARMAsmParser
+    AArch64CodeGen
+    AArch64AsmParser
+    X86CodeGen
+    X86AsmParser
 )
 
 if(APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,8 @@ set(LLVM_LIBS_DEP
   demangle
   OrcJIT
   native
+  ARMCodeGen
+  ARMAsmParser
   AArch64CodeGen
   AArch64AsmParser
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,8 @@ set(LLVM_LIBS_DEP
   demangle
   OrcJIT
   native
+  AArch64CodeGen
+  AArch64AsmParser
 )
 
 if(APPLE)

--- a/src/core/jitter.cpp
+++ b/src/core/jitter.cpp
@@ -41,6 +41,13 @@ Jitter::Jitter(const std::string &Triple)
   InitializeNativeTarget();
   InitializeNativeTargetAsmParser();
   InitializeNativeTargetAsmPrinter();
+
+  // Explicitly initialize the AArch64 target
+  LLVMInitializeAArch64Target();
+  LLVMInitializeAArch64TargetMC();
+  LLVMInitializeAArch64TargetInfo();
+  LLVMInitializeAArch64AsmParser();
+  LLVMInitializeAArch64AsmPrinter();
 }
 
 std::unique_ptr<orc::LLJIT> Jitter::compile(Module &M) {

--- a/src/include/omvll/jitter.hpp
+++ b/src/include/omvll/jitter.hpp
@@ -48,10 +48,11 @@ private:
   std::string Triple;
   std::unique_ptr<llvm::LLVMContext> Ctx;
 
-  bool hasInitializedARMAssembler = false;
+  static bool HasArchTargetInitialized;
+  void initializeArchTarget();
   void initializeARMAssembler();
-  bool hasInitializedAArch64Assembler = false;
   void initializeAArch64Assembler();
+  void initializeX86Assembler();
 };
 
 } // end namespace omvll

--- a/src/include/omvll/jitter.hpp
+++ b/src/include/omvll/jitter.hpp
@@ -47,6 +47,11 @@ protected:
 private:
   std::string Triple;
   std::unique_ptr<llvm::LLVMContext> Ctx;
+
+  bool hasInitializedARMAssembler = false;
+  void initializeARMAssembler();
+  bool hasInitializedAArch64Assembler = false;
+  void initializeAArch64Assembler();
 };
 
 } // end namespace omvll


### PR DESCRIPTION
Fixes #33

Tests:
Successfully Compiled O-MVLL on linux.

Verified that all tests pass with `ninja check`
```
-- Testing: 23 tests, 23 workers --
PASS: O-MVLL Tests :: core/plugin/find-omvll-config-cwd.c (1 of 23)
XFAIL: O-MVLL Tests :: passes/break-cfg/basic-aarch64-ios.c (2 of 23)
XFAIL: O-MVLL Tests :: passes/cfg-flattening/basic-aarch64-ios.c (3 of 23)
PASS: O-MVLL Tests :: passes/cfg-flattening/basic-aarch64-android.c (4 of 23)
PASS: O-MVLL Tests :: passes/arithmetic/xor-arm-android.c (5 of 23)
PASS: O-MVLL Tests :: passes/string-encoding/basic-ios-swift.ll (6 of 23)
PASS: O-MVLL Tests :: passes/cfg-flattening/basic-arm-android.c (7 of 23)
PASS: O-MVLL Tests :: passes/string-encoding/string-encoding-global-exclude-x86_64-linux.c (8 of 23)
PASS: O-MVLL Tests :: passes/arithmetic/arithmetic-global-exclude-x86_64-linux.c (9 of 23)
PASS: O-MVLL Tests :: passes/arithmetic/report_diff-x86_64-linux.c (10 of 23)
PASS: O-MVLL Tests :: passes/cfg-flattening/cfg-flattening-global-exclude-x86_64-linux.c (11 of 23)
PASS: O-MVLL Tests :: core/plugin/find-omvll-config-plugindir.c (12 of 23)
PASS: O-MVLL Tests :: passes/string-encoding/basic-aarch64-optlocal.ll (13 of 23)
PASS: O-MVLL Tests :: passes/cfg-flattening/basic-native.c (14 of 23)
PASS: O-MVLL Tests :: passes/string-encoding/basic-aarch64-ce-init.ll (15 of 23)
PASS: O-MVLL Tests :: passes/string-encoding/basic-arm-android.cpp (16 of 23)
XFAIL: O-MVLL Tests :: passes/arithmetic/xor-aarch64-ios.c (17 of 23)
PASS: O-MVLL Tests :: passes/opaque-constants/opaque-constants-infinite-loop.ll (18 of 23)
PASS: O-MVLL Tests :: passes/arithmetic/xor-x86_64-linux.c (19 of 23)
PASS: O-MVLL Tests :: passes/arithmetic/xor-aarch64-android.c (20 of 23)
XFAIL: O-MVLL Tests :: passes/arithmetic/xor-x86_64-darwin.c (21 of 23)
PASS: O-MVLL Tests :: passes/string-encoding/basic-aarch64.cpp (22 of 23)
PASS: O-MVLL Tests :: passes/arithmetic/default-config-x86_64-linux.c (23 of 23)
********************
Expectedly Failed Tests (4):
  O-MVLL Tests :: passes/arithmetic/xor-aarch64-ios.c
  O-MVLL Tests :: passes/arithmetic/xor-x86_64-darwin.c
  O-MVLL Tests :: passes/break-cfg/basic-aarch64-ios.c
  O-MVLL Tests :: passes/cfg-flattening/basic-aarch64-ios.c


Testing Time: 0.39s

Total Discovered Tests: 23
  Passed           : 19 (82.61%)
  Expectedly Failed:  4 (17.39%)
```