### PR TITLE
Support Android target on macOS hosts

### DIFF
--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -8,22 +8,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: O-MVLL Xcode 16.x
+      - name: O-MVLL Build Plugins
         shell: bash
         run: |
-          curl -LO https://open-obfuscator.build38.io/static/omvll-deps-xcode-16_3.tar
+          curl -LO https://github.com/weliveindetail/o-mvll/releases/download/v1.4.0-mock/omvll-v1.4-macos-deps.tar
           mkdir -p /tmp/third-party-xcode16
-          mkdir -p $GITHUB_WORKSPACE/dist
-          tar xvf ./omvll-deps-xcode-16_3.tar --directory=/tmp/third-party-xcode16
+          tar xvf ./omvll-v1.4-macos-deps.tar --directory=/tmp/third-party-xcode16
           docker run --rm \
-            -v /tmp/third-party-xcode16:/third-party \
+            -v /tmp/third-party-xcode16/omvll-v1.4-macos-deps:/deps \
             -v $GITHUB_WORKSPACE:/o-mvll \
             openobfuscator/omvll-build:latest bash /o-mvll/scripts/docker/xcode_16_compile.sh
-      - name: O-MVLL Signing
+      - name: O-MVLL Sign Xcode Plugin
         uses: indygreg/apple-code-sign-action@v1.0
         with:
-          input_path: ${{ github.workspace }}/src/build_xcode/omvll_unsigned.dylib
-          output_path: ${{ github.workspace }}/src/build_xcode/omvll_xcode_16.dylib
+          input_path: ${{ github.workspace }}/src/build_xcode/omvll_xcode_unsigned.dylib
+          output_path: ${{ github.workspace }}/src/build_xcode/omvll_xcode.dylib
+          p12_file: ${{ github.workspace }}/scripts/certificates/SigningCertificate.p12
+          p12_password: ${{ secrets.certificate_password }}
+      - name: O-MVLL Sign NDK Plugin
+        uses: indygreg/apple-code-sign-action@v1.0
+        with:
+          input_path: ${{ github.workspace }}/src/build_xcode/omvll_ndk_unsigned.dylib
+          output_path: ${{ github.workspace }}/src/build_xcode/omvll_ndk.dylib
           p12_file: ${{ github.workspace }}/scripts/certificates/SigningCertificate.p12
           p12_password: ${{ secrets.certificate_password }}
       - name: Generate distribution folder
@@ -31,7 +37,8 @@ jobs:
         run: |
           curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz
           tar xzvf Python-3.10.7.tgz --directory=${{ github.workspace }}/dist/
-          cp ${{ github.workspace }}/src/build_xcode/omvll_xcode_16.dylib ${{ github.workspace }}/dist/
+          cp ${{ github.workspace }}/src/build_xcode/omvll-xcode.dylib ${{ github.workspace }}/dist/
+          cp ${{ github.workspace }}/src/build_xcode/omvll-ndk.dylib ${{ github.workspace }}/dist/
       - name: Generate deployment tar
         uses: a7ul/tar-action@v1.1.3
         id: compress
@@ -39,10 +46,11 @@ jobs:
           command: c
           cwd: ${{ github.workspace }}/dist
           files: |
-            ./omvll_xcode_16.dylib
+            ./omvll-xcode.dylib
+            ./omvll-ndk.dylib
             ./Python-3.10.7
             ./sample-omvll-config.py
-          outPath: ${{ github.workspace }}/dist/omvll_xcode_16_3.tar.gz
+          outPath: ${{ github.workspace }}/dist/omvll-v1.4-macos.tar.gz
       - name: O-MVLL Deployment
         env:
           BUILD38_S3_KEY: ${{ secrets.BUILD38_S3_KEY }}

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -11,7 +11,7 @@ jobs:
       - name: O-MVLL Build Plugins
         shell: bash
         run: |
-          curl -LO https://github.com/weliveindetail/o-mvll/releases/download/v1.4.0-mock/omvll-v1.4-macos-deps.tar
+          curl -LO https://open-obfuscator.build38.io/static/omvll-v1.4.0-macos-deps.tar
           mkdir -p /tmp/third-party-xcode16
           tar xvf ./omvll-v1.4-macos-deps.tar --directory=/tmp/third-party-xcode16
           docker run --rm \

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -21,15 +21,15 @@ jobs:
       - name: O-MVLL Sign Xcode Plugin
         uses: indygreg/apple-code-sign-action@v1.0
         with:
-          input_path: ${{ github.workspace }}/src/build_xcode/omvll_xcode_unsigned.dylib
-          output_path: ${{ github.workspace }}/src/build_xcode/omvll_xcode.dylib
+          input_path: ${{ github.workspace }}/src/build_xcode/omvll-xcode_unsigned.dylib
+          output_path: ${{ github.workspace }}/src/build_xcode/omvll-xcode.dylib
           p12_file: ${{ github.workspace }}/scripts/certificates/SigningCertificate.p12
           p12_password: ${{ secrets.certificate_password }}
       - name: O-MVLL Sign NDK Plugin
         uses: indygreg/apple-code-sign-action@v1.0
         with:
-          input_path: ${{ github.workspace }}/src/build_xcode/omvll_ndk_unsigned.dylib
-          output_path: ${{ github.workspace }}/src/build_xcode/omvll_ndk.dylib
+          input_path: ${{ github.workspace }}/src/build_xcode/omvll-ndk_unsigned.dylib
+          output_path: ${{ github.workspace }}/src/build_xcode/omvll-ndk.dylib
           p12_file: ${{ github.workspace }}/scripts/certificates/SigningCertificate.p12
           p12_password: ${{ secrets.certificate_password }}
       - name: Generate distribution folder

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl -LO https://open-obfuscator.build38.io/static/omvll-v1.4.0-macos-deps.tar
           mkdir -p /tmp/third-party-xcode16
-          tar xvf ./omvll-v1.4-macos-deps.tar --directory=/tmp/third-party-xcode16
+          tar xvf ./omvll-v1.4.0-macos-deps.tar --directory=/tmp/third-party-xcode16
           docker run --rm \
             -v /tmp/third-party-xcode16/omvll-v1.4-macos-deps:/deps \
             -v $GITHUB_WORKSPACE:/o-mvll \

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -15,7 +15,7 @@ jobs:
           mkdir -p /tmp/third-party-xcode16
           tar xvf ./omvll-v1.4.0-macos-deps.tar --directory=/tmp/third-party-xcode16
           docker run --rm \
-            -v /tmp/third-party-xcode16/omvll-v1.4-macos-deps:/deps \
+            -v /tmp/third-party-xcode16/omvll-v1.4.0-macos-deps:/deps \
             -v $GITHUB_WORKSPACE:/o-mvll \
             openobfuscator/omvll-build:latest bash /o-mvll/scripts/docker/xcode_16_compile.sh
       - name: O-MVLL Sign Xcode Plugin
@@ -50,7 +50,7 @@ jobs:
             ./omvll-ndk.dylib
             ./Python-3.10.7
             ./sample-omvll-config.py
-          outPath: ${{ github.workspace }}/dist/omvll-v1.4-macos.tar.gz
+          outPath: ${{ github.workspace }}/dist/omvll-v1.4.0-macos.tar.gz
       - name: O-MVLL Deployment
         env:
           BUILD38_S3_KEY: ${{ secrets.BUILD38_S3_KEY }}

--- a/scripts/docker/ndk_r26_compile.sh
+++ b/scripts/docker/ndk_r26_compile.sh
@@ -31,6 +31,8 @@ cp ${NDK_STAGE2}/bin/clang++ /test-deps/bin
 
 cd /o-mvll/src
 mkdir -p o-mvll-build_ndk_r26d && cd o-mvll-build_ndk_r26d
+
+# TODO: switch to release NDK
 cmake -GNinja .. \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_COMPILER=${NDK_STAGE1}/bin/clang++ \
@@ -43,7 +45,8 @@ cmake -GNinja .. \
       -Dspdlog_DIR=/data/spdlog-1.10.0-Linux/lib/cmake/spdlog \
       -DLLVM_DIR=${NDK_STAGE2}/lib/cmake/llvm \
       -DLLVM_TOOLS_DIR=/test-deps \
-      -DLLVM_EXTERNAL_LIT=/test-deps/bin/llvm-lit
+      -DLLVM_EXTERNAL_LIT=/test-deps/bin/llvm-lit \
+      -DOMVLL_ABI=CustomAndroid
 
 export OMVLL_PYTHONPATH=/Python-3.10.7/Lib
 ninja check

--- a/scripts/docker/xcode_16_compile.sh
+++ b/scripts/docker/xcode_16_compile.sh
@@ -101,8 +101,8 @@ cmake -GNinja -Bndk-x86_64 -S.. \
       -DOMVLL_ABI=Android
 ninja -C ndk-x86_64
 
-lipo -create -output /o-mvll/src/build_xcode/omvll_xcode_unsigned.dylib ./xcode-arm64/libOMVLL.dylib ./xcode-x86_64/libOMVLL.dylib
-lipo -create -output /o-mvll/src/build_xcode/omvll_ndk_unsigned.dylib ./ndk-arm64/libOMVLL.dylib ./ndk-x86_64/libOMVLL.dylib
+lipo -create -output omvll-xcode_unsigned.dylib ./xcode-arm64/libOMVLL.dylib ./xcode-x86_64/libOMVLL.dylib
+lipo -create -output omvll-ndk_unsigned.dylib ./ndk-arm64/libOMVLL.dylib ./ndk-x86_64/libOMVLL.dylib
 
 chown -R 1000:1000 /o-mvll/src/build_xcode
 chmod -R 777 /o-mvll/src/build_xcode

--- a/scripts/docker/xcode_16_compile.sh
+++ b/scripts/docker/xcode_16_compile.sh
@@ -6,32 +6,27 @@
 
 set -ex
 
-mkdir -p /deps && cd /deps
-
-cp /third-party/omvll-deps-xcode-*/LLVM-19.1.4git-arm64-Darwin.tar.gz .
-cp /third-party/omvll-deps-xcode-*/LLVM-19.1.4git-x86_64-Darwin.tar.gz .
-cp /third-party/omvll-deps-xcode-*/Python-slim.tar.gz .
-cp /third-party/omvll-deps-xcode-*/pybind11.tar.gz .
-cp /third-party/omvll-deps-xcode-*/spdlog-1.10.0-Darwin.tar.gz .
-
+cd /deps
 tar xzvf LLVM-19.1.4git-arm64-Darwin.tar.gz
 tar xzvf LLVM-19.1.4git-x86_64-Darwin.tar.gz
+tar xzvf LLVM17-NDK26-Darwin.tar.gz
 tar xzvf Python-slim.tar.gz
 tar xzvf pybind11.tar.gz
 tar xzvf spdlog-1.10.0-Darwin.tar.gz
 
 cd /o-mvll/src
+
+# TODO: rename, build_macos?
 mkdir -p build_xcode && cd build_xcode
 
 export OSXCROSS_TARGET_DIR=/osxcross
 export OSXCROSS_SDK=${OSXCROSS_TARGET_DIR}/SDK/MacOSX15.4.sdk
 export OMVLL_PYTHONPATH=/omvll/ci/distribution/Python-3.10.7/Lib
-mkdir -p arm64 && cd arm64
 
 export OSXCROSS_HOST="arm64-apple-darwin24.4"
 export OSXCROSS_TARGET="arm64-apple-darwin24.4"
 
-cmake -GNinja ../.. \
+cmake -GNinja -Bxcode-arm64 -S.. \
       -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
       -DCMAKE_OSX_DEPLOYMENT_TARGET="15.4" \
       -DOSXCROSS_HOST=${OSXCROSS_HOST} \
@@ -45,17 +40,32 @@ cmake -GNinja ../.. \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
-      -DLLVM_DIR=/deps/LLVM-19.1.4git-arm64-Darwin/lib/cmake/llvm
+      -DLLVM_DIR=/deps/LLVM-19.1.4git-arm64-Darwin/lib/cmake/llvm \
+      -DOMVLL_ABI=Apple
+ninja -C xcode-arm64
 
-ninja
-
-cd ..
-mkdir -p x86_64 && cd x86_64
+cmake -GNinja -Bndk-arm64 -S.. \
+      -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET="15.4" \
+      -DOSXCROSS_HOST=${OSXCROSS_HOST} \
+      -DOSXCROSS_TARGET_DIR=${OSXCROSS_TARGET_DIR} \
+      -DOSXCROSS_SDK=${OSXCROSS_SDK} \
+      -DOSXCROSS_TARGET=${OSXCROSS_TARGET} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DPYBIND11_NOPYTHON=1 \
+      -DPython3_ROOT_DIR=/deps \
+      -DPython3_LIBRARY=/deps/lib/libpython3.10.a \
+      -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
+      -Dpybind11_DIR=/deps/share/cmake/pybind11 \
+      -Dspdlog_DIR=/deps/lib/cmake/spdlog \
+      -DLLVM_DIR=/deps/LLVM17-NDK26-Darwin/lib/cmake/llvm \
+      -DOMVLL_ABI=Android
+ninja -C ndk-arm64
 
 export OSXCROSS_HOST="x86_64-apple-darwin24.4"
 export OSXCROSS_TARGET="x86_64-apple-darwin24.4"
 
-cmake -GNinja ../.. \
+cmake -GNinja -Bxcode-x86_64 -S.. \
       -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
       -DCMAKE_OSX_DEPLOYMENT_TARGET="15.4" \
       -DOSXCROSS_HOST=${OSXCROSS_HOST} \
@@ -69,12 +79,30 @@ cmake -GNinja ../.. \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
-      -DLLVM_DIR=/deps/LLVM-19.1.4-Darwin/lib/cmake/llvm
+      -DLLVM_DIR=/deps/LLVM-19.1.4-Darwin/lib/cmake/llvm \
+      -DOMVLL_ABI=Apple
+ninja -C xcode-x86_64
 
-ninja
-cd ..
+cmake -GNinja -Bndk-x86_64 -S.. \
+      -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET="15.4" \
+      -DOSXCROSS_HOST=${OSXCROSS_HOST} \
+      -DOSXCROSS_TARGET_DIR=${OSXCROSS_TARGET_DIR} \
+      -DOSXCROSS_SDK=${OSXCROSS_SDK} \
+      -DOSXCROSS_TARGET=${OSXCROSS_TARGET} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DPYBIND11_NOPYTHON=1 \
+      -DPython3_ROOT_DIR=/deps \
+      -DPython3_LIBRARY=/deps/lib/libpython3.10.a \
+      -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
+      -Dpybind11_DIR=/deps/share/cmake/pybind11 \
+      -Dspdlog_DIR=/deps/lib/cmake/spdlog \
+      -DLLVM_DIR=/deps/LLVM17-NDK26-Darwin/lib/cmake/llvm \
+      -DOMVLL_ABI=Android
+ninja -C ndk-x86_64
 
-lipo -create -output omvll.dylib ./arm64/libOMVLL.dylib ./x86_64/libOMVLL.dylib
-mv /o-mvll/src/build_xcode/omvll.dylib /o-mvll/src/build_xcode/omvll_unsigned.dylib
+lipo -create -output /o-mvll/src/build_xcode/omvll_xcode_unsigned.dylib ./xcode-arm64/libOMVLL.dylib ./xcode-x86_64/libOMVLL.dylib
+lipo -create -output /o-mvll/src/build_xcode/omvll_ndk_unsigned.dylib ./ndk-arm64/libOMVLL.dylib ./ndk-x86_64/libOMVLL.dylib
+
 chown -R 1000:1000 /o-mvll/src/build_xcode
 chmod -R 777 /o-mvll/src/build_xcode

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,8 +21,20 @@ option(OMVLL_FORCE_LOG_DEBUG "Force the log debug output" OFF)
 option(OMVLL_PY_STANDALONE   "Build OMVLL as a standalone Python module" OFF)
 
 if(APPLE)
-  set(LLVM_REQUIRED_VERSION 19.1.4)
+  set(OMVLL_DEFAULT_ABI "Apple")
 else()
+  set(OMVLL_DEFAULT_ABI "Android")
+endif()
+
+set(OMVLL_ABI "" CACHE STRING
+  "Compiler ABI to build OMVLL against. Supported options are \"Apple\" and \"Android\". Defaults to ${OMVLL_DEFAULT_ABI}.")
+
+if(OMVLL_ABI STREQUAL "Apple")
+  set(LLVM_REQUIRED_VERSION 19.1.4)
+elseif(OMVLL_ABI STREQUAL "Android")
+  set(LLVM_REQUIRED_VERSION 17)
+else()
+  # TODO: switch Linux build to release NDK
   set(LLVM_REQUIRED_VERSION 17.0.2)
 endif()
 
@@ -183,9 +195,14 @@ llvm_map_components_to_libnames(llvm_libs
   ${LLVM_LIBS_DEP}
 )
 
-target_link_libraries(OMVLL PRIVATE
-  ${llvm_libs}
-)
+# TODO: double-check with NDK on Linux
+if(OMVLL_ABI STREQUAL "Android")
+  target_link_libraries(OMVLL PRIVATE LLVM)
+else()
+  target_link_libraries(OMVLL PRIVATE
+    ${llvm_libs}
+  )
+endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Release AND NOT OMVLL_FORCE_LOG_DEBUG)
   if(APPLE)


### PR DESCRIPTION
In order to build and obfuscate Android Apps on macOS host platforms, we need a plugin dylib that works with the NDK toolchain. This patch tweaks the existing Xcode CI workflow to build such a plugin for both architectures, arm64 and x86_64.

The macOS platform release https://github.com/android/ndk/releases/tag/r26d only ships the x86_64 executables, but contained libraries are universal. We can link the plugin against its `libLLVM.dylib` for both architectures, arm64 and x86_64. The binary release lacks headers and CMake config, but we can get that from a simple config of the matching source checkout from https://android.googlesource.com/toolchain/llvm-project/+/refs/heads/llvm-r487747