### PR TITLE
Drop dots from distribution package name

### DIFF
--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -50,7 +50,7 @@ jobs:
             ./omvll-ndk.dylib
             ./Python-3.10.7
             ./sample-omvll-config.py
-          outPath: ${{ github.workspace }}/dist/omvll-v1.4.0-macos.tar.gz
+          outPath: ${{ github.workspace }}/dist/omvll_v1-4-0_macos.tar.gz
       - name: O-MVLL Deployment
         env:
           BUILD38_S3_KEY: ${{ secrets.BUILD38_S3_KEY }}


### PR DESCRIPTION
Deployment script considers all dots as separators for file extensions https://github.com/open-obfuscator/o-mvll/blob/main/.github/scripts/s3-deploy.py#L141-L149 and inserted the timestamp in the middle of the name. Let's fix that by not using dots in the package's semver. We might revisit that when we update the Linux workflow.

With this patch, package names are:
```
omvll_ndk_r26.tar.gz --> omvll_ndk_r26_2025-05-12T12:13:54.tar.gz
omvll_v1-4-0_macos.tar.gz --> omvll_v1-4-0_macos_2025-05-12T12:13:54.tar.gz
```