### PR TITLE
Find clang executable next to current host compiler

### DIFF
--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -52,7 +52,7 @@ static Expected<std::string> getAppleClangPath() {
   if (StringRef(HostExePath).ends_with("clang"))
     return HostExePath;
 
-  SmallString<128> ClangPath = llvm::sys::path::parent_path(HostExePath);
+  SmallString<128> ClangPath = sys::path::parent_path(HostExePath);
   llvm::sys::path::append(ClangPath, "clang");
   if (llvm::sys::fs::exists(ClangPath))
     return ClangPath.str().str();

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -55,7 +55,7 @@ static Expected<std::string> getAppleClangPath() {
   SmallString<128> ClangPath = sys::path::parent_path(HostExePath);
   llvm::sys::path::append(ClangPath, "clang");
   if (llvm::sys::fs::exists(ClangPath))
-    return ClangPath.str().str();
+    return std::string(ClangPath);
 
   return createStringError(inconvertibleErrorCode(),
                            "Cannot find clang compiler: " + ClangPath);

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -45,9 +45,20 @@ static int runExecutable(SmallVectorImpl<StringRef> &Args,
   return sys::ExecuteAndWait(Args[0], Args, Envs, Redirects);
 }
 
-static std::string getAppleClangPath() {
+static Expected<std::string> getAppleClangPath() {
   static int Unused;
-  return sys::fs::getMainExecutable("clang", (void *)&Unused);
+  std::string HostExePath =
+      sys::fs::getMainExecutable("clang", (void *)&Unused);
+  if (StringRef(HostExePath).ends_with("clang"))
+    return HostExePath;
+
+  SmallString<128> ClangPath = llvm::sys::path::parent_path(HostExePath);
+  llvm::sys::path::append(ClangPath, "clang");
+  if (llvm::sys::fs::exists(ClangPath))
+    return ClangPath.str().str();
+
+  return createStringError(inconvertibleErrorCode(),
+                           "Cannot find clang compiler: " + ClangPath);
 }
 
 static Expected<std::string> getIPhoneOSSDKPath() {
@@ -66,10 +77,12 @@ static Expected<std::string> getIPhoneOSSDKPath() {
   SmallVector<StringRef, 8> Args = {XcrunPath, "--sdk", "iphoneos",
                                     "--show-sdk-path"};
 
-  const auto &ClangPath = getAppleClangPath();
-  size_t DirPos = ClangPath.find("/Contents/Developer");
+  Expected<std::string> ClangPath = getAppleClangPath();
+  if (!ClangPath)
+    return ClangPath.takeError();
+  size_t DirPos = ClangPath->find("/Contents/Developer");
   std::string DeveloperDir =
-      ClangPath.substr(0, DirPos + strlen("/Contents/Developer"));
+      ClangPath->substr(0, DirPos + strlen("/Contents/Developer"));
   const auto &DeveloperDirEnvVar = "DEVELOPER_DIR=" + DeveloperDir;
   SmallVector<StringRef, 1> Envs = {DeveloperDirEnvVar};
 
@@ -96,7 +109,8 @@ static Expected<std::string>
 runClangExecutable(StringRef Code, StringRef Dashx, const Triple &Triple,
                    const std::vector<std::string> &ExtraArgs) {
   const auto &ClangPath = getAppleClangPath();
-  SmallVector<StringRef, 16> Args = {ClangPath, "-S", "-emit-llvm"};
+  SINFO("ClangPath: {}", *ClangPath);
+  SmallVector<StringRef, 16> Args = {*ClangPath, "-S", "-emit-llvm"};
 
   // Always add the target triple.
   const auto &TargetTriple = Triple.str();


### PR DESCRIPTION
If the plugin is not running in clang directly, we expect to find it on the same path as our host executable.