### PR TITLE
Skip coroutines in various passes

### DIFF
--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -48,6 +48,7 @@ size_t reg2mem(llvm::Function &F);
 void shuffleFunctions(llvm::Module &M);
 bool isModuleGloballyExcluded(llvm::Module *M);
 bool isFunctionGloballyExcluded(llvm::Function *F);
+bool isCoroutine(llvm::Function *F);
 bool containsSwiftErrorAlloca(const llvm::BasicBlock &BB);
 bool isEHBlock(const llvm::BasicBlock &BB);
 

--- a/src/passes/basic-block-duplicate/BasicBlockDuplicate.cpp
+++ b/src/passes/basic-block-duplicate/BasicBlockDuplicate.cpp
@@ -181,6 +181,9 @@ PreservedAnalyses BasicBlockDuplicate::run(Module &M,
   for (Function &F : M) {
     Opt = Config.getUserConfig()->basicBlockDuplicate(&M, &F);
 
+    if (isCoroutine(&F))
+      continue;
+
     auto *P = std::get_if<BasicBlockDuplicateWithProbability>(&Opt);
     if (P && !isFunctionGloballyExcluded(&F) && !F.isDeclaration() &&
         !F.isIntrinsic() && !F.getName().starts_with("__omvll"))

--- a/src/passes/cfg-flattening/ControlFlowFlattening.cpp
+++ b/src/passes/cfg-flattening/ControlFlowFlattening.cpp
@@ -488,6 +488,9 @@ PreservedAnalyses ControlFlowFlattening::run(Module &M,
         F.getName().starts_with("__omvll"))
       continue;
 
+    if (isCoroutine(&F))
+      continue;
+
     bool MadeChange = runOnFunction(F, *RNG);
     if (MadeChange)
       reg2mem(F);

--- a/src/passes/function-outline/FunctionOutline.cpp
+++ b/src/passes/function-outline/FunctionOutline.cpp
@@ -137,7 +137,8 @@ PreservedAnalyses FunctionOutline::run(Module &M, ModuleAnalysisManager &MAM) {
 
     auto *P = std::get_if<FunctionOutlineWithProbability>(&Opt);
     if (P && !isFunctionGloballyExcluded(&F) && !F.isDeclaration() &&
-        !F.isIntrinsic() && !F.getName().starts_with("__omvll"))
+        !F.isIntrinsic() && !F.getName().starts_with("__omvll") &&
+        !isCoroutine(&F))
       ToVisit.emplace_back(&F, P->Probability);
   }
 

--- a/src/passes/indirect-branch/IndirectBranch.cpp
+++ b/src/passes/indirect-branch/IndirectBranch.cpp
@@ -152,6 +152,9 @@ PreservedAnalyses IndirectBranch::run(Module &M, ModuleAnalysisManager &MAM) {
     if (!Opt || !*Opt)
       continue;
 
+    if (isCoroutine(&F))
+      continue;
+
     if (isFunctionGloballyExcluded(&F) ||
         F.hasFnAttribute(Attribute::AlwaysInline) || F.isDeclaration() ||
         F.isIntrinsic() || F.getName().starts_with("__omvll"))


### PR DESCRIPTION
This patch lets the following passes skip co-routines, because they are not supported yet:
* BasicBlockDuplicate
* IndirectBranch
* ControlFlowFlattening