### PR TITLE
Replace `DenseSet` with `SmallPtrSet` in passes

### DIFF
--- a/src/passes/cfg-flattening/ControlFlowFlattening.cpp
+++ b/src/passes/cfg-flattening/ControlFlowFlattening.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/Constants.h"
@@ -135,7 +136,7 @@ bool ControlFlowFlattening::runOnFunction(Function &F,
   demotePHINode(F);
 
   BasicBlock *EntryBlock = &F.getEntryBlock();
-  DenseSet<BasicBlock *> NormalDest2Split;
+  SmallPtrSet<BasicBlock *, 8> NormalDest2Split;
 
   auto IsFromInvoke = [](const auto &BB) {
     return any_of(predecessors(&BB), [](const auto *Pred) {

--- a/src/passes/indirect-branch/IndirectBranch.cpp
+++ b/src/passes/indirect-branch/IndirectBranch.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -30,7 +31,7 @@ bool IndirectBranch::process(Function &F, const DataLayout &DL,
                              LLVMContext &Ctx) {
   Module &M = *F.getParent();
   std::vector<Instruction *> TerminatorsToReplace;
-  DenseSet<BasicBlock *> SuccBlocks;
+  SmallPtrSet<BasicBlock *, 32> SuccBlocks;
 
   // Gather jumps and switch instructions.
   for (BasicBlock &BB : F) {


### PR DESCRIPTION
`SmallPtrSet` is the recommended type for storing small pointer values and it uses small size optimization to avoid heap allocation if possible. The chosen capacity of 32 (indirect branch) and 8 (CFG flattening) should cover most complex targets.

See https://llvm.org/docs/ProgrammersManual.html#llvm-adt-denseset-h