### PR TITLE
Fix arithmetic pass logging to show opcode

### DIFF
--- a/src/passes/arithmetic/Arithmetic.cpp
+++ b/src/passes/arithmetic/Arithmetic.cpp
@@ -202,7 +202,7 @@ bool Arithmetic::runOnBasicBlock(BasicBlock &BB) {
             continue;
 
           SINFO("[{}][{}] Replacing {} with {}", name(), F->getName(),
-                I.getName(), Result->getName());
+                I.getOpcodeName(), Result->getName());
 
           BasicBlock *InstParent = I.getParent();
           BasicBlock::iterator InsertPos = I.getIterator();


### PR DESCRIPTION
Use `getOpcodeName()` to fix logging of unnamed instructions.

Before:
`[omvll::Arithmetic][__omvll_mba] Replacing  with mba_add`

After:
`[omvll::Arithmetic][__omvll_mba] Replacing add with mba_add`