### PR TITLE
Sync version numbers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ if(EXISTS       "${CMAKE_CURRENT_SOURCE_DIR}/../.git" AND
   include(GitInfo)
 else()
   set(OMVLL_VERSION_MAJOR "1")
-  set(OMVLL_VERSION_MINOR "0")
+  set(OMVLL_VERSION_MINOR "4")
   set(OMVLL_VERSION_PATCH "1")
 endif()
 

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -111,7 +111,7 @@ PassPluginLibraryInfo getOMVLLPluginInfo() {
   omvll::initYamlConfig();
   omvll::initPythonpath();
 
-  return {LLVM_PLUGIN_API_VERSION, "OMVLL", "1.1.0", [](PassBuilder &PB) {
+  return {LLVM_PLUGIN_API_VERSION, "OMVLL", "1.4.1", [](PassBuilder &PB) {
             try {
               auto &Instance = omvll::PyConfig::instance();
               SDEBUG("Found OMVLL at: {}", Instance.configPath());


### PR DESCRIPTION
The OMVLL version number is hardcoded in various places in the codebase which are out of sync. This commit synchronizes them, at least partially.