### PR TITLE
Fix fatal error logging, refactor to `string_view`

### DIFF
--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -440,14 +440,12 @@ void shuffleFunctions(Module &M) {
   });
 }
 
-void fatalError(const std::string &Msg) { fatalError(Msg.c_str()); }
-
-void fatalError(const char *Msg) {
+void fatalError(std::string_view Msg) {
   static LLVMContext Ctx;
+  SERR("Error: {}", Msg);
   Ctx.emitError(Msg);
 
   // emitError could return, so we make sure that we stop the execution.
-  SERR("Error: {}", Msg);
   std::abort();
 }
 

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -52,8 +52,7 @@ bool isCoroutine(llvm::Function *F);
 bool containsSwiftErrorAlloca(const llvm::BasicBlock &BB);
 bool isEHBlock(const llvm::BasicBlock &BB);
 
-[[noreturn]] void fatalError(const char *Msg);
-[[noreturn]] void fatalError(const std::string &Msg);
+[[noreturn]] void fatalError(std::string_view Msg);
 
 llvm::Expected<std::unique_ptr<llvm::Module>>
 generateModule(llvm::StringRef Routine, const llvm::Triple &Triple,


### PR DESCRIPTION
Fatal errors were only visible in Xcode report navigator which is annoying to navigate IMO. Now they are present in
the logfile as well. I think the original code intended to log the error but the logging statement was unreachable after `emitError()` was called.

Also refactored to use `string_view`, eliminating the need for overloads.