### PR TITLE
Make icall more resilient in release builds

### DIFF
--- a/src/passes/indirect-call/IndirectCall.cpp
+++ b/src/passes/indirect-call/IndirectCall.cpp
@@ -88,8 +88,10 @@ bool IndirectCall::process(Function &F, const DataLayout &DL,
     Value *PtrS2 =
         Builder.CreateInBoundsGEP(ArrTy, GVAddrShares2, {Zero, Index});
 
-    Value *Share1 = Builder.CreateLoad(IntPtrTy, PtrS1);
-    Value *Share2 = Builder.CreateLoad(IntPtrTy, PtrS2);
+    // Mark load as volatile to prevent simplification of the indirect calls
+    // by the optimizer.
+    Value *Share1 = Builder.CreateLoad(IntPtrTy, PtrS1, /* isVolatile */ true);
+    Value *Share2 = Builder.CreateLoad(IntPtrTy, PtrS2, /* isVolatile */ true);
 
     Value *Address = Builder.CreateSub(Share2, Share1);
     SDEBUG("[{}] Rewriting call-site: {}", name(), ToString(*CI));

--- a/src/test/passes/indirect-call/basic-aarch64-ios.ll
+++ b/src/test/passes/indirect-call/basic-aarch64-ios.ll
@@ -5,29 +5,32 @@
 ; REQUIRES: aarch64-registered-target && apple_abi
 
 ; RUN: env OMVLL_CONFIG=%S/config_all.py clang++ -fpass-plugin=%libOMVLL \
-; RUN:         -target arm64-apple-ios17.5.0 -O0 -S -emit-llvm %s -o - | FileCheck --check-prefixes=CHECK-O0 %s
+; RUN:         -target arm64-apple-ios17.5.0 -O0 -S -emit-llvm %s -o - | FileCheck --check-prefixes=CHECK,CHECK-O0 %s
 
 ; RUN: env OMVLL_CONFIG=%S/config_all.py clang++ -fpass-plugin=%libOMVLL \
-; RUN:         -target arm64-apple-ios17.5.0 -O1 -S -emit-llvm %s -o - | FileCheck --check-prefixes=CHECK-O1 %s
+; RUN:         -target arm64-apple-ios17.5.0 -O1 -S -emit-llvm %s -o - | FileCheck --check-prefixes=CHECK,CHECK-O1 %s
 
-; CHECK-O0: @[[ICALL_SHARES1:.*]] = internal constant [2 x i64] [i64 {{.*}}, i64 {{.*}}]
-; CHECK-O0: @[[ICALL_SHARES2:.*]] = internal constant [2 x i64] [i64 add (i64 ptrtoint (ptr @foo to i64), i64 {{.*}}), i64 add (i64 ptrtoint (ptr @qux to i64), i64 {{.*}})]
+; CHECK: @[[ICALL_SHARES1:.*]] = internal constant [2 x i64] [i64 {{.*}}, i64 {{.*}}]
+; CHECK: @[[ICALL_SHARES2:.*]] = internal constant [2 x i64] [i64 add (i64 ptrtoint (ptr @foo to i64), i64 {{.*}}), i64 add (i64 ptrtoint (ptr @qux to i64), i64 {{.*}})]
 
 define void @simple_calls() {
 ; CHECK-LABEL:  define void @simple_calls(
 ; CHECK-LABEL:  entry
-; CHECK-O0:       [[LD1:%.*]] = load i64, ptr @[[ICALL_SHARES1]], align 8
-; CHECK-O0-NEXT:  [[LD2:%.*]] = load i64, ptr @[[ICALL_SHARES2]], align 8
+; CHECK-O0:       [[LD1:%.*]] = load volatile i64, ptr @[[ICALL_SHARES1]], align 8
+; CHECK-O0-NEXT:  [[LD2:%.*]] = load volatile i64, ptr @[[ICALL_SHARES2]], align 8
 ; CHECK-O0-NEXT:  [[SUB:%.*]] = sub i64 [[LD2]], [[LD1]]
 ; CHECK-O0-NEXT:  [[INT2PTR:%.*]] = inttoptr i64 [[SUB]] to ptr
 ; CHECK-O0-NEXT:  call void [[INT2PTR]]()
-; CHECK-O0-NEXT:  [[LD3:%.*]] = load i64, ptr getelementptr inbounds ([2 x i64], ptr @[[ICALL_SHARES1]], i64 0, i64 1), align 8
-; CHECK-O0-NEXT:  [[LD4:%.*]] = load i64, ptr getelementptr inbounds ([2 x i64], ptr @[[ICALL_SHARES2]], i64 0, i64 1), align 8
+; CHECK-O0-NEXT:  [[LD3:%.*]] = load volatile i64, ptr getelementptr inbounds ([2 x i64], ptr @[[ICALL_SHARES1]], i64 0, i64 1), align 8
+; CHECK-O0-NEXT:  [[LD4:%.*]] = load volatile i64, ptr getelementptr inbounds ([2 x i64], ptr @[[ICALL_SHARES2]], i64 0, i64 1), align 8
 ; CHECK-O0-NEXT:  [[SUB2:%.*]] = sub i64 [[LD4]], [[LD3]]
 ; CHECK-O0-NEXT:  [[INT2PTR2:%.*]] = inttoptr i64 [[SUB2]] to ptr
 ; CHECK-O0-NEXT:  call void [[INT2PTR2]]()
-; CHECK-O1:       call void inttoptr (i64 sub (i64 add (i64 ptrtoint (ptr @foo to i64), i64 {{.*}}), i64 {{.*}}) to ptr)()
-; CHECK-O1-NEXT:  call void inttoptr (i64 sub (i64 add (i64 ptrtoint (ptr @qux to i64), i64 {{.*}}), i64 {{.*}}) to ptr)()
+; CHECK-O1:       [[LD1_O1:%.*]] = load volatile i64, ptr @[[ICALL_SHARES1]], align 8
+; CHECK-O1-NEXT:  [[LD2_O1:%.*]] = load volatile i64, ptr @[[ICALL_SHARES2]], align 8
+; CHECK-O1-NEXT:  [[SUB_O1:%.*]] = sub i64 [[LD2_O1]], [[LD1_O1]]
+; CHECK-O1-NEXT:  [[INT2PTR_O1:%.*]] = inttoptr i64 [[SUB_O1]] to ptr
+; CHECK-O1-NEXT:  tail call void [[INT2PTR_O1]]()
 entry:
   call void @foo()
   call void @qux()


### PR DESCRIPTION
Previously, optimizations in release builds (particularly on iOS) were eliminating/simplifying indirect call patterns making reversing easy.

Mark load instructions as volatile to preserve the indirection and increase resilience against static analysis.

Test code:

```obj-c
#include "test.h"
#import <Cocoa/Cocoa.h>

int main(int argc, const char * argv[]) {
    my_function();
    @autoreleasepool {
        // Setup code that might create autoreleased objects goes here.
    }
    return NSApplicationMain(argc, argv);
}
```

```c
#include "stdio.h"
#include "test.h"

void my_function(void) {
    puts("Hello!");
}
```

Assembly:

Before:

```
$ llvm-objdump --disassemble-symbols=_main ./build/Build/Products/Release/weak.app/Contents/MacOS/weak       

./build/Build/Products/Release/weak.app/Contents/MacOS/weak:	file format mach-o arm64

Disassembly of section __TEXT,__text:

0000000100000998 <_main>:
...
1000009ac: 90000008    	adrp	x8, 0x100000000 <_puts+0x100000000>
1000009b0: 91277108    	add	x8, x8, #0x9dc
1000009b4: d63f0100    	blr	x8
...
$ llvm-nm ./build/Build/Products/Release/weak.app/Contents/MacOS/weak | grep my_function              
00000001000009dc t _my_function
$ llvm-nm ./build/Build/Products/Release/weak.app/Contents/MacOS/weak | grep icall
```

After:

```
$ llvm-objdump --disassemble-symbols=_main ./build/Build/Products/Release/weak.app/Contents/MacOS/weak

./build/Build/Products/Release/weak.app/Contents/MacOS/weak:	file format mach-o arm64

Disassembly of section __TEXT,__text:

0000000100000a38 <_main>:
...
100000a50: b0000015    	adrp	x21, 0x100001000 <_puts+0x100001000>
100000a54: 912b22b5    	add	x21, x21, #0xac8
100000a58: f94002a8    	ldr	x8, [x21]
100000a5c: 90000036    	adrp	x22, 0x100004000 <_puts+0x100004000>
100000a60: 910062d6    	add	x22, x22, #0x18
100000a64: f94002c9    	ldr	x9, [x22]
100000a68: cb080128    	sub	x8, x9, x8
100000a6c: d63f0100    	blr	x8
...
$ llvm-nm ./build/Build/Products/Release/weak.app/Contents/MacOS/weak | grep my_function                                
0000000100000a9c t _my_function
$ llvm-nm ./build/Build/Products/Release/weak.app/Contents/MacOS/weak | grep icall
0000000100001ac8 s _.icall.shares1
0000000100001ad8 s _.icall.shares1
0000000100004018 s _.icall.shares2
0000000100004028 s _.icall.shares2
```

Cutter:

Before:

```c
// WARNING: Variable defined which should be unmapped: var_18h
// WARNING: Variable defined which should be unmapped: var_20h
// WARNING: Variable defined which should be unmapped: var_10h
// WARNING: Variable defined which should be unmapped: var_8h

void entry0(int64_t arg1, int64_t arg2)
{
    int64_t var_20h;
    int64_t var_18h;
    int64_t var_10h;
    int64_t var_8h;
    
    _my_function();
    objc_autoreleasePoolPush();
    objc_autoreleasePoolPop();
    // WARNING: Could not recover jumptable at 0x0001000009d8. Too many branches
    // WARNING: Treating indirect jump as call
    (*_NSApplicationMain)(arg1, arg2);
    return;
}
```

```c
void _my_function(void)
{
    // WARNING: Could not recover jumptable at 0x0001000009ec. Too many branches
    // WARNING: Treating indirect jump as call
    (*_puts)("Hello!");
    return;
}
```

After:

```c
// WARNING: Variable defined which should be unmapped: var_18h
// WARNING: Variable defined which should be unmapped: var_20h
// WARNING: Variable defined which should be unmapped: var_28h
// WARNING: Variable defined which should be unmapped: var_30h
// WARNING: Variable defined which should be unmapped: var_10h
// WARNING: Variable defined which should be unmapped: var_8h

void entry0(int64_t arg1, int64_t arg2)
{
    int64_t var_30h;
    int64_t var_28h;
    int64_t var_20h;
    int64_t var_18h;
    int64_t var_10h;
    int64_t var_8h;
    
    (*(code *)(__.icall.shares2 + -0xc8893400))();
    objc_autoreleasePoolPush();
    objc_autoreleasePoolPop();
    // WARNING: Could not recover jumptable at 0x000100000a98. Too many branches
    // WARNING: Treating indirect jump as call
    (*(code *)(_NSApplicationMain + -0xc73abe00))(arg1, arg2);
    return;
}
```

```c
void _my_function(void)
{
    // WARNING: Could not recover jumptable at 0x000100000ab8. Too many branches
    // WARNING: Treating indirect jump as call
    (*(code *)(_puts + -0x73880500))(str.Hello);
    return;
}
```

Ghidra:

Before:

```c
void entry(undefined8 param_1,undefined8 param_2)

{
  _my_function();
  _objc_autoreleasePoolPush();
  _objc_autoreleasePoolPop();
  (*(code *)PTR__NSApplicationMain_100004020)(param_1,param_2);
  return;
}
```

```c
void _my_function(void)

{
  (*(code *)PTR__puts_100004018)("Hello!");
  return;
}
```

After:

```c
void entry(undefined8 param_1,undefined8 param_2)

{
  _my_function();
  _objc_autoreleasePoolPush();
  _objc_autoreleasePoolPop();
  (*(code *)&LAB_38c68200)(param_1,param_2);
  return;
}
```

```c
void _my_function(void)

{
  (*(code *)&LAB_8c793b30)("Hello!");
  return;
}
```