### PR TITLE
Ensure thread-safe plugin initialization in whole-module optimization

### DIFF
--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -131,7 +131,7 @@ Logger::Logger() {
 }
 
 void Logger::BindModule(const std::string &Module, const std::string &Arch) {
-  // TODO: Shouldn't be necessary even in whole-module compilation mode.
+  static thread_local ThreadLoggerGuard Guard;
   std::lock_guard<std::mutex> Lock(BindLog);
 
   // If OutputFolder is now set, migrate init log (once)

--- a/src/include/omvll/PyConfig.hpp
+++ b/src/include/omvll/PyConfig.hpp
@@ -48,14 +48,16 @@ public:
 
   static inline YamlConfig YConfig;
 
+  PyConfig(const PyConfig &) = delete;
+  PyConfig &operator=(const PyConfig &) = delete;
+
 private:
   PyConfig();
   ~PyConfig();
-  static void destroy();
 
   std::unique_ptr<pybind11::module_> Mod;
   std::unique_ptr<pybind11::module_> CoreMod;
-  static inline PyConfig *Instance = nullptr;
+  std::string ModulePath;
 };
 
 } // end namespace omvll

--- a/src/include/omvll/log.hpp
+++ b/src/include/omvll/log.hpp
@@ -70,13 +70,10 @@ public:
   static void set_level(LogLevel L);
 
   static void BindModule(const std::string &Module, const std::string &Arch);
-
-private:
   static std::shared_ptr<spdlog::logger> CurrentOrDefault();
 
 private:
   Logger();
-  static Logger &Instance();
   spdlog::level::level_enum Level = spdlog::level::debug;
 
   // Default sink used before any thread binds a module.
@@ -84,6 +81,23 @@ private:
 
   // Per-thread bound module sink.
   static thread_local std::shared_ptr<spdlog::logger> Current;
+
+public:
+  static Logger &Instance();
+};
+
+class ThreadLoggerGuard {
+public:
+  ThreadLoggerGuard() = default;
+
+  ~ThreadLoggerGuard() {
+    auto Current = Logger::Instance().CurrentOrDefault();
+    if (Current)
+      Current->flush();
+  }
+
+  ThreadLoggerGuard(const ThreadLoggerGuard &) = delete;
+  ThreadLoggerGuard &operator=(const ThreadLoggerGuard &) = delete;
 };
 
 } // end namespace omvll

--- a/src/test/swift-wmo/Inputs/bar.swift
+++ b/src/test/swift-wmo/Inputs/bar.swift
@@ -1,0 +1,6 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+public func bar() -> Int { return foo() + 1 }

--- a/src/test/swift-wmo/Inputs/config_swift_wmo.py
+++ b/src/test/swift-wmo/Inputs/config_swift_wmo.py
@@ -1,0 +1,17 @@
+#
+# This file is distributed under the Apache License v2.0. See LICENSE for details.
+#
+
+import omvll
+from functools import lru_cache
+
+class MyConfig(omvll.ObfuscationConfig):
+    def __init__(self):
+        super().__init__()
+    def obfuscate_arithmetic(self, mod: omvll.Module,
+                                   fun: omvll.Function) -> omvll.ArithmeticOpt:
+        return True
+
+@lru_cache(maxsize=1)
+def omvll_get_config() -> omvll.ObfuscationConfig:
+    return MyConfig()

--- a/src/test/swift-wmo/Inputs/foo.swift
+++ b/src/test/swift-wmo/Inputs/foo.swift
@@ -1,0 +1,6 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+public func foo() -> Int { return 2 }

--- a/src/test/swift-wmo/basic-swift-wmo.swift
+++ b/src/test/swift-wmo/basic-swift-wmo.swift
@@ -1,0 +1,16 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+// REQUIRES: apple_abi && aarch64-registered-target
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: env OMVLL_CONFIG=%S/Inputs/config_swift_wmo.py swift-frontend \
+// RUN:     -wmo -target arm64-apple-ios14.0 -load-pass-plugin=%libOMVLL -Onone -num-threads 8 \
+// RUN:     %S/Inputs/foo.swift %S/Inputs/bar.swift %s -emit-ir %EXTRA_SWIFT_FLAGS \
+// RUN:     -o %t/bar.ll -o %t/foo.ll -o %t/main.ll
+// RUN: FileCheck %s < %t/main.ll
+
+// CHECK: define swiftcc i64 @"$s3foo4mainSiyF"() {{.*}} {
+public func main() -> Int { return foo() + bar() }


### PR DESCRIPTION
When using Swift whole-module optimization mode, the compiler optimizes all files within a single module as a whole. The module may be later split into different parts, which are processed by LLVM in multiple threads. Make sure the plugin infrastructure remain thread-safe in this scenario as well, by acquiring/releasing the Python GIL when needed before accessing Python configs.