### PR TITLE
Fix Function Outline compile-time and runtime errors

### DIFF
--- a/src/passes/function-outline/FunctionOutline.cpp
+++ b/src/passes/function-outline/FunctionOutline.cpp
@@ -65,6 +65,18 @@ static bool outliningMayBeUnfavorable(const BasicBlock &BB) {
   return false;
 }
 
+static bool hasAllocaInputWithLifetime(const SetVector<Value *> &Inputs) {
+  for (Value *V : Inputs) {
+    auto *AI = dyn_cast<AllocaInst>(V);
+    if (!AI)
+      continue;
+    for (const User *U : AI->users())
+      if (isa<LifetimeIntrinsic>(U))
+        return true;
+  }
+  return false;
+}
+
 static bool isOutlineCandidate(const BasicBlock &BB) {
   if (BB.size() < 3)
     return false;
@@ -143,6 +155,12 @@ bool FunctionOutline::process(Function &F, LLVMContext &Ctx,
     SetVector<Value *> Inputs, Outputs, SinkCands;
     CE.findInputsOutputs(Inputs, Outputs, SinkCands);
     if (hasSwiftErrorOrSwiftSelfAttribute(Inputs))
+      continue;
+
+    // Skip blocks whose alloca inputs already have lifetime markers. CodeExtractor
+    // always injects a lifetime.start for every alloca crossing the boundary,
+    // which would create a duplicate and allow DSE to treat prior stores as dead.
+    if (hasAllocaInputWithLifetime(Inputs))
       continue;
 
     // Outline region and replace the original block with a call-site to the


### PR DESCRIPTION
`getIntrinsicID()` does not recognize typed-pointer variants such as
`llvm.va_start.p0`, which causes stack-frame-dependent intrinsics to
be missed. Added a name-prefix check for `llvm.va_start`, `llvm.va_copy`,
and `llvm.va_end` as a fallback to ensure all variants are caught
regardless of any type suffix.

`CodeExtractor` injects a `lifetime.start` for every `alloca` crossing the
extraction boundary. If the frontend already emitted one, this creates
a duplicate, allowing DSE to treat prior stores as dead and causing
functions to receive garbage pointers at runtime. Fixed by skipping 
blocks whose `alloca` inputs already have lifetime markers.