### PR TITLE
FuncOutline: Skip outlining of with.overflow intrinsics

### DIFF
--- a/src/passes/function-outline/FunctionOutline.cpp
+++ b/src/passes/function-outline/FunctionOutline.cpp
@@ -50,6 +50,9 @@ static bool outliningMayBeUnfavorable(const BasicBlock &BB) {
           Name.starts_with("llvm.va_copy") || Name.starts_with("llvm.va_end")) {
         return true;
       }
+
+      if (Name.contains("with.overflow"))
+        return true;
     }
 
     if (auto *CB = dyn_cast<CallBase>(&I)) {


### PR DESCRIPTION
Function Outline fails to outline blocks that contain special intrinsics that return a struct (with.overflow). In this commit we skip all blocks that contain such instructions.