### PR TITLE
Utils: Replace std::rand with C++11 RNG facilities

### DIFF
--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -588,19 +588,15 @@ bool isEHBlock(const BasicBlock &BB) {
 
 // Default value is false.
 bool RandomGenerator::Seeded = false;
+std::mt19937_64 RandomGenerator::MtEngine;
 
 uint64_t RandomGenerator::generateFullRand() {
   if (!RandomGenerator::Seeded) {
-    std::srand(Config.ProbabilitySeed);
+    RandomGenerator::MtEngine.seed(Config.ProbabilitySeed);
     RandomGenerator::Seeded = true;
   }
 
-  uint64_t r = 0;
-  for (int i = 0; i < 5; ++i) {
-    r = (r << 15) ^ static_cast<uint64_t>(std::rand() & 0x7FFF);
-  }
-
-  return r;
+  return static_cast<uint64_t>(RandomGenerator::MtEngine());
 }
 
 // Generate a random number: a <= rnd <= b
@@ -608,20 +604,14 @@ uint64_t RandomGenerator::generateRange(uint64_t a, uint64_t b) {
   if (a > b)
     report_fatal_error("The range for a random must be a <= b.");
 
-  uint64_t range = b - a + 1;
+  if (!RandomGenerator::Seeded) {
+    RandomGenerator::MtEngine.seed(Config.ProbabilitySeed);
+    RandomGenerator::Seeded = true;
+  }
 
-  if (range == 0)
-    return generateFullRand();
+  std::uniform_int_distribution<uint64_t> Distrib(a, b);
 
-  uint64_t limit = std::numeric_limits<uint64_t>::max() -
-                   (std::numeric_limits<uint64_t>::max() % range);
-
-  uint64_t rnd;
-  do {
-    rnd = generateFullRand();
-  } while (rnd > limit);
-
-  return a + (rnd % range);
+  return Distrib(RandomGenerator::MtEngine);
 }
 
 int RandomGenerator::generate() {

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -5,13 +5,14 @@
 // details.
 //
 
+#include <random>
 #include <string>
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/TargetParser/Triple.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/Error.h"
+#include "llvm/TargetParser/Triple.h"
 
 // Forward declarations
 namespace llvm {
@@ -94,6 +95,7 @@ private:
 class RandomGenerator {
 private:
   static bool Seeded;
+  static std::mt19937_64 MtEngine;
 
 public:
   static uint64_t generateFullRand();

--- a/src/test/passes/arithmetic/default-config-x86_64-linux-android.c
+++ b/src/test/passes/arithmetic/default-config-x86_64-linux-android.c
@@ -25,86 +25,75 @@
 
 // CHECK-LABEL: memcpy_xor:
 // CHECK:       .LBB0_2:
-// CHECK-NEXT:      movl    %eax, %ecx
-// CHECK-NEXT:      movsbl  (%rsi,%rcx), %r8d
-// CHECK-NEXT:      movl    %r8d, %r9d
-// CHECK-NEXT:      notl    %r9d
-// CHECK-NEXT:      leal    (%r8,%r9,2), %r10d
-// CHECK-NEXT:      leal    (%r8,%r9,2), %r9d
-// CHECK-NEXT:      incl    %r9d
-// CHECK-NEXT:      notl    %r9d
-// CHECK-NEXT:      orl     $35, %r9d
-// CHECK-NEXT:      addl    %r10d, %r9d
-// CHECK-NEXT:      incl    %r9d
-// CHECK-NEXT:      movl    %r8d, %r10d
-// CHECK-NEXT:      xorl    $221, %r10d
-// CHECK-NEXT:      andl    $93, %r8d
-// CHECK-NEXT:      leal    (%r10,%r8,2), %r8d
-// CHECK-NEXT:      leal    (%r8,%r9,2), %r8d
-// CHECK-NEXT:      addb    $2, %r8b
-// CHECK-NEXT:      movb    %r8b, (%rdi,%rcx)
-// CHECK-NEXT:      movl    %eax, %ecx
-// CHECK-NEXT:      xorl    $2, %ecx
-// CHECK-NEXT:      andl    $2, %eax
-// CHECK-NEXT:      leal    (%rcx,%rax,2), %eax
-// CHECK-NEXT:      movl    %eax, %ecx
-// CHECK-NEXT:      notl    %ecx
-// CHECK-NEXT:      leal    (%rcx,%rax,2), %eax
-// CHECK-NEXT:      cmpl    %edx, %eax
-// CHECK-NEXT:      jb      .LBB0_2
+// CHECK-NEXT:     	movsbl	(%rsi,%rcx), %edx
+// CHECK-NEXT:     	movl	%edx, %r8d
+// CHECK-NEXT:     	notl	%r8d
+// CHECK-NEXT:     	orl	$-36, %r8d
+// CHECK-NEXT:     	addl	%edx, %r8d
+// CHECK-NEXT:     	addl	$36, %r8d
+// CHECK-NEXT:     	andl	$35, %edx
+// CHECK-NEXT:     	negl	%edx
+// CHECK-NEXT:     	movl	%r8d, %r9d
+// CHECK-NEXT:     	xorl	%edx, %r9d
+// CHECK-NEXT:     	andl	%r8d, %edx
+// CHECK-NEXT:     	leal	(%r9,%rdx,2), %edx
+// CHECK-NEXT:     	movb	%dl, (%rdi,%rcx)
+// CHECK-NEXT:     	incq	%rcx
+// CHECK-NEXT:     	cmpq	%rcx, %rax
+// CHECK-NEXT:     	jne	.LBB0_2
 
 // This is the exact same config as CHECK (include_function) but with
 // a different probability seed, thus the instruction changes
 // NEWSEED-LABEL: memcpy_xor:
 // NEWSEED:     .LBB0_2:
-// NEWSEED-NEXT:  	movl    %eax, %ecx
-// NEWSEED-NEXT:  	movsbl  (%rsi,%rcx), %r8d
-// NEWSEED-NEXT:  	movl    %r8d, %r9d
-// NEWSEED-NEXT:  	notl    %r9d
-// NEWSEED-NEXT:  	leal    (%r8,%r9,2), %r10d
-// NEWSEED-NEXT:  	leal    (%r8,%r9,2), %r9d
-// NEWSEED-NEXT:  	incl    %r9d
-// NEWSEED-NEXT:  	notl    %r9d
-// NEWSEED-NEXT:  	orl     $35, %r9d
-// NEWSEED-NEXT:  	addl    %r10d, %r9d
-// NEWSEED-NEXT:  	incl    %r9d
-// NEWSEED-NEXT:  	movl    %r8d, %r10d
-// NEWSEED-NEXT:  	xorl    $221, %r10d
-// NEWSEED-NEXT:  	andl    $93, %r8d
-// NEWSEED-NEXT:  	leal    (%r10,%r8,2), %r8d
-// NEWSEED-NEXT:  	leal    (%r8,%r9,2), %r8d
-// NEWSEED-NEXT:  	addb    $2, %r8b
-// NEWSEED-NEXT:  	movb    %r8b, (%rdi,%rcx)
-// NEWSEED-NEXT:  	movl    %eax, %ecx
-// NEWSEED-NEXT:  	xorl    $2, %ecx
-// NEWSEED-NEXT:  	andl    $2, %eax
-// NEWSEED-NEXT:  	leal    (%rcx,%rax,2), %eax
-// NEWSEED-NEXT:  	movl    %eax, %ecx
-// NEWSEED-NEXT:  	notl    %ecx
-// NEWSEED-NEXT:  	leal    (%rcx,%rax,2), %eax
-// NEWSEED-NEXT:  	cmpl    %edx, %eax
-// NEWSEED-NEXT:  	jb      .LBB0_2
+// NEWSEED-NEXT   	movl	%eax, %ecx
+// NEWSEED-NEXT   	movsbl	(%rsi,%rcx), %r8d
+// NEWSEED-NEXT   	movl	%r8d, %r9d
+// NEWSEED-NEXT   	notl	%r9d
+// NEWSEED-NEXT   	orl	$-36, %r9d
+// NEWSEED-NEXT   	addl	%r8d, %r9d
+// NEWSEED-NEXT   	addl	$36, %r9d
+// NEWSEED-NEXT   	andl	$35, %r8d
+// NEWSEED-NEXT   	negl	%r8d
+// NEWSEED-NEXT   	movl	%r9d, %r10d
+// NEWSEED-NEXT   	xorl	%r8d, %r10d
+// NEWSEED-NEXT   	andl	%r9d, %r8d
+// NEWSEED-NEXT   	leal	(%r10,%r8,2), %r8d
+// NEWSEED-NEXT   	movb	%r8b, (%rdi,%rcx)
+// NEWSEED-NEXT   	movl	%eax, %ecx
+// NEWSEED-NEXT   	notl	%ecx
+// NEWSEED-NEXT   	movl	%ecx, %r8d
+// NEWSEED-NEXT   	orl	$1, %r8d
+// NEWSEED-NEXT   	orl	$-2, %ecx
+// NEWSEED-NEXT   	addl	%r8d, %ecx
+// NEWSEED-NEXT   	leal	(%rcx,%rax,2), %eax
+// NEWSEED-NEXT   	addl	$3, %eax
+// NEWSEED-NEXT   	cmpl	%edx, %eax
+// NEWSEED-NEXT   	jb	.LBB0_2
+
 
 // CHECKV2-LABEL: memcpy_xor:
 // CHECKV2:     .LBB0_2:
-// CHECKV2-NEXT:   	movzbl  (%rsi,%rcx), %edx
-// CHECKV2-NEXT:   	movl    %edx, %r8d
-// CHECKV2-NEXT:   	notb    %r8b
-// CHECKV2-NEXT:   	addb    %r8b, %r8b
-// CHECKV2-NEXT:   	addb    %dl, %r8b
-// CHECKV2-NEXT:   	addb    %r8b, %r8b
-// CHECKV2-NEXT:   	movl    %edx, %r9d
-// CHECKV2-NEXT:   	xorb    $-35, %r9b
-// CHECKV2-NEXT:   	addb    %dl, %dl
-// CHECKV2-NEXT:   	andb    $-70, %dl
-// CHECKV2-NEXT:   	addb    %r9b, %dl
-// CHECKV2-NEXT:   	addb    $2, %r8b
-// CHECKV2-NEXT:   	andb    $70, %r8b
-// CHECKV2-NEXT:   	addb    %dl, %r8b
-// CHECKV2-NEXT:   	movb    %r8b, (%rdi,%rcx)
-// CHECKV2-NEXT:   	incq    %rcx
-// CHECKV2-NEXT:   	cmpq    %rcx, %rax
-// CHECKV2-NEXT:   	jne     .LBB0_2
+// CHECKV2-NEXT:   	movl	%eax, %ecx
+// CHECKV2-NEXT:   	movzbl	(%rsi,%rcx), %r8d
+// CHECKV2-NEXT:   	movl	%r8d, %r9d
+// CHECKV2-NEXT:   	notb	%r9b
+// CHECKV2-NEXT:   	orb	$-36, %r9b
+// CHECKV2-NEXT:   	addb	%r8b, %r9b
+// CHECKV2-NEXT:   	andb	$35, %r8b
+// CHECKV2-NEXT:   	subb	%r8b, %r9b
+// CHECKV2-NEXT:   	addb	$36, %r9b
+// CHECKV2-NEXT:   	movb	%r9b, (%rdi,%rcx)
+// CHECKV2-NEXT:   	movl	%eax, %ecx
+// CHECKV2-NEXT:   	xorl	$2, %ecx
+// CHECKV2-NEXT:   	andl	$2, %eax
+// CHECKV2-NEXT:   	leal	(%rcx,%rax,2), %eax
+// CHECKV2-NEXT:   	movl	%eax, %ecx
+// CHECKV2-NEXT:   	notl	%ecx
+// CHECKV2-NEXT:   	leal	(%rcx,%rax,2), %eax
+// CHECKV2-NEXT:   	cmpl	%edx, %eax
+// CHECKV2-NEXT:   	jb	.LBB0_2
+
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/arithmetic/default-config-x86_64-linux-ios.c
+++ b/src/test/passes/arithmetic/default-config-x86_64-linux-ios.c
@@ -27,7 +27,10 @@
 // CHECK:       .LBB0_2:
 // CHECK-NEXT:      movsbl  (%rsi,%rcx), %edx
 // CHECK-NEXT:      movl    %edx, %r8d
-// CHECK-NEXT:      orl     $35, %r8d
+// CHECK-NEXT:      notl    %r8d
+// CHECK-NEXT:      orl     $-36, %r8d
+// CHECK-NEXT:      addl    %edx, %r8d
+// CHECK-NEXT:      addl    $36, %r8d
 // CHECK-NEXT:      andl    $35, %edx
 // CHECK-NEXT:      negl    %edx
 // CHECK-NEXT:      movl    %r8d, %r9d
@@ -43,44 +46,42 @@
 // a different probability seed, thus the instruction changes
 // NEWSEED-LABEL: memcpy_xor:
 // NEWSEED:     .LBB0_2:
-// NEWSEED:     movl    %eax, %ecx
-// NEWSEED:     movsbl  (%rsi,%rcx), %r8d
-// NEWSEED:     movl    %r8d, %r9d
-// NEWSEED:     xorl    $221, %r9d
-// NEWSEED:     addl    %r8d, %r8d
-// NEWSEED:     movl    %r8d, %r10d
-// NEWSEED:     notl    %r10d
-// NEWSEED:     andl    $186, %r8d
-// NEWSEED:     addl    %r9d, %r8d
-// NEWSEED:     andl    $70, %r10d
-// NEWSEED:     addl    %r8d, %r10d
-// NEWSEED:     movb    %r10b, (%rdi,%rcx)
-// NEWSEED:     movl    %eax, %ecx
-// NEWSEED:     andl    $-2, %ecx
-// NEWSEED:     addl    %eax, %ecx
-// NEWSEED:     notl    %eax
-// NEWSEED:     orl     $1, %eax
-// NEWSEED:     addl    %ecx, %eax
-// NEWSEED:     addl    $2, %eax
-// NEWSEED:     cmpl    %edx, %eax
-// NEWSEED:     jb      .LBB0_2
+// NEWSEED-NEXT:    movl    %eax, %ecx
+// NEWSEED-NEXT:    movsbl  (%rsi,%rcx), %r8d
+// NEWSEED-NEXT:    movl    %r8d, %r9d
+// NEWSEED-NEXT:    notl    %r9d
+// NEWSEED-NEXT:    orl     $-36, %r9d
+// NEWSEED-NEXT:    addl    %r8d, %r9d
+// NEWSEED-NEXT:    addl    $36, %r9d
+// NEWSEED-NEXT:    andl    $35, %r8d
+// NEWSEED-NEXT:    negl    %r8d
+// NEWSEED-NEXT:    movl    %r9d, %r10d
+// NEWSEED-NEXT:    xorl    %r8d, %r10d
+// NEWSEED-NEXT:    andl    %r9d, %r8d
+// NEWSEED-NEXT:    leal    (%r10,%r8,2), %r8d
+// NEWSEED-NEXT:    movb    %r8b, (%rdi,%rcx)
+// NEWSEED-NEXT:    incl    %eax
+// NEWSEED-NEXT:    cmpl    %edx, %eax
+// NEWSEED-NEXT:    jb      .LBB0_2
 
 // CHECKV2-LABEL: memcpy_xor:
 // CHECKV2:     .LBB0_2:
-// CHECKV2-NEXT:    movsbl  (%rsi,%rcx), %edx
-// CHECKV2-NEXT:    movl    %edx, %r8d
-// CHECKV2-NEXT:    xorl    $221, %r8d
-// CHECKV2-NEXT:    addl    %edx, %edx
-// CHECKV2-NEXT:    movl    %edx, %r9d
-// CHECKV2-NEXT:    notl    %r9d
-// CHECKV2-NEXT:    andl    $186, %edx
-// CHECKV2-NEXT:    addl    %r8d, %edx
-// CHECKV2-NEXT:    andl    $70, %r9d
-// CHECKV2-NEXT:    addl    %edx, %r9d
-// CHECKV2-NEXT:    movb    %r9b, (%rdi,%rcx)
-// CHECKV2-NEXT:    incq    %rcx
-// CHECKV2-NEXT:    cmpq    %rcx, %rax
-// CHECKV2-NEXT:    jne     .LBB0_2
+// CHECKV2-NEXT:    movl    %eax, %ecx
+// CHECKV2-NEXT:    movzbl  (%rsi,%rcx), %r8d
+// CHECKV2-NEXT:    leal    (%r8,%r8), %r9d
+// CHECKV2-NEXT:    andb    $70, %r9b
+// CHECKV2-NEXT:    subb    %r9b, %r8b
+// CHECKV2-NEXT:    addb    $35, %r8b
+// CHECKV2-NEXT:    movb    %r8b, (%rdi,%rcx)
+// CHECKV2-NEXT:    movl    %eax, %ecx
+// CHECKV2-NEXT:    xorl    $2, %ecx
+// CHECKV2-NEXT:    andl    $2, %eax
+// CHECKV2-NEXT:    leal    (%rcx,%rax,2), %eax
+// CHECKV2-NEXT:    movl    %eax, %ecx
+// CHECKV2-NEXT:    notl    %ecx
+// CHECKV2-NEXT:    leal    (%rcx,%rax,2), %eax
+// CHECKV2-NEXT:    cmpl    %edx, %eax
+// CHECKV2-NEXT:    jb      .LBB0_2
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/arithmetic/xor-aarch64-android.c
+++ b/src/test/passes/arithmetic/xor-aarch64-android.c
@@ -21,79 +21,58 @@
 
 // R1-LABEL: memcpy_xor:
 // R1:       .LBB0_2:
-// R1-NEXT:      ldrb	w11, [x1], #1
-// R1-NEXT:      subs	x8, x8, #1
-// R1-NEXT:      bic	w12, w9, w11, lsl #1
-// R1-NEXT:      add	w11, w11, w12
-// R1-NEXT:      sub	w11, w11, #35
-// R1-NEXT:      strb	w11, [x10], #1
-// R1-NEXT:      b.ne	.LBB0_2
+// R1-NEXT:   	ldrb	w11, [x1], #1
+// R1-NEXT:   	subs	x8, x8, #1
+// R1-NEXT:   	eor	w11, w11, w9
+// R1-NEXT:   	strb	w11, [x10], #1
+// R1-NEXT:   	b.ne	.LBB0_2
 
 // R2-LABEL: memcpy_xor:
 // R2:       .LBB0_2:
-// R2-NEXT:      mov     w10, w9
-// R2-NEXT:      lsl     w13, w9, #1
-// R2-NEXT:      eor     w9, w9, #0x2
-// R2-NEXT:      and     w13, w13, #0x4
-// R2-NEXT:      add     w9, w13, w9
-// R2-NEXT:      ldrb    w11, [x1, x10]
-// R2-NEXT:      mvn     w12, w11
-// R2-NEXT:      add     w12, w11, w12, lsl #1
-// R2-NEXT:      add     w12, w12, #1
-// R2-NEXT:      orn     w14, w8, w12
-// R2-NEXT:      add     w12, w12, w14
-// R2-NEXT:      lsl     w14, w11, #1
-// R2-NEXT:      eor     w11, w11, #0xdddddddd
-// R2-NEXT:      and     w14, w14, #0xbbbbbbbb
-// R2-NEXT:      add     w11, w14, w11
-// R2-NEXT:      add     w11, w11, w12, lsl #1
-// R2-NEXT:      mvn     w12, w9
-// R2-NEXT:      add     w9, w12, w9, lsl #1
-// R2-NEXT:      add     w11, w11, #2
-// R2-NEXT:      cmp     w9, w2
-// R2-NEXT:      strb    w11, [x0, x10]
-// R2-NEXT:      b.lo    .LBB0_2
+// R2-NEXT:      ldrb	w12, [x1], #1
+// R2-NEXT:      subs	x8, x8, #1
+// R2-NEXT:      orn	w13, w9, w12
+// R2-NEXT:      add	w13, w12, w13
+// R2-NEXT:      and	w12, w12, w10
+// R2-NEXT:      add	w13, w13, #36
+// R2-NEXT:      neg	w12, w12
+// R2-NEXT:      and	w14, w13, w12
+// R2-NEXT:      eor	w12, w13, w12
+// R2-NEXT:      add	w12, w12, w14, lsl #1
+// R2-NEXT:      strb	w12, [x11], #1
+// R2-NEXT:      b.ne	.LBB0_2
+
 
 // R3-LABEL: memcpy_xor:
 // R3:       .LBB0_2:
-// R3-NEXT:      mov     w12, w8
-// R3-NEXT:      ldrb    w13, [x1, x12]
-// R3-NEXT:      mvn     w14, w13
-// R3-NEXT:      lsl     w16, w13, #1
-// R3-NEXT:      eor     w15, w13, #0x1
-// R3-NEXT:      and     w17, w16, #0x2
-// R3-NEXT:      add     w14, w13, w14, lsl #1
-// R3-NEXT:      add     w15, w15, w17
-// R3-NEXT:      bic     w16, w10, w16
-// R3-NEXT:      add     w14, w15, w14, lsl #1
-// R3-NEXT:      add     w14, w14, #2
-// R3-NEXT:      mvn     w15, w14
-// R3-NEXT:      add     w14, w14, w15, lsl #1
-// R3-NEXT:      add     w15, w14, #1
-// R3-NEXT:      orn     w17, w9, w15
-// R3-NEXT:      add     w15, w15, w17
-// R3-NEXT:      orn     w17, w11, w13
-// R3-NEXT:      add     w15, w15, #36
-// R3-NEXT:      add     w17, w13, w17
-// R3-NEXT:      eon     w3, w14, w15
-// R3-NEXT:      bic     w14, w15, w14
-// R3-NEXT:      lsl     w15, w8, #1
-// R3-NEXT:      add     w17, w17, w3
-// R3-NEXT:      and     w15, w15, #0x4
-// R3-NEXT:      add     w14, w17, w14, lsl #1
-// R3-NEXT:      add     w17, w8, w15
-// R3-NEXT:      eor     w15, w15, #0x4
-// R3-NEXT:      add     w15, w17, w15
-// R3-NEXT:      add     w13, w13, w16
-// R3-NEXT:      sub     w15, w15, #2
-// R3-NEXT:      add     w13, w13, w14, lsl #1
-// R3-NEXT:      orr     w14, w15, #0x1
-// R3-NEXT:      orr     w8, w8, #0xfffffffe
-// R3-NEXT:      add     w8, w8, w14
-// R3-NEXT:      add     w13, w13, #37
-// R3-NEXT:      cmp     w8, w2
-// R3-NEXT:      strb    w13, [x0, x12]
-// R3-NEXT:      b.lo    .LBB0_2
+// R3-NEXT:      mov	w11, w9
+// R3-NEXT:      ldrb	w12, [x1, x11]
+// R3-NEXT:      mvn	w13, w12
+// R3-NEXT:      orr	w14, w12, w10
+// R3-NEXT:      add	w15, w12, #35
+// R3-NEXT:      neg	w14, w14
+// R3-NEXT:      add	w13, w12, w13, lsl #1
+// R3-NEXT:      and	w16, w15, w14
+// R3-NEXT:      eor	w14, w15, w14
+// R3-NEXT:      add	w13, w13, #1
+// R3-NEXT:      orr	w13, w13, w8
+// R3-NEXT:      add	w14, w14, w16, lsl #1
+// R3-NEXT:      lsl	w15, w9, #1
+// R3-NEXT:      add	w12, w12, w13
+// R3-NEXT:      neg	w13, w14
+// R3-NEXT:      and	w14, w15, #0x4
+// R3-NEXT:      add	w12, w12, #36
+// R3-NEXT:      add	w9, w9, w14
+// R3-NEXT:      eor	w14, w14, #0x4
+// R3-NEXT:      and	w15, w12, w13
+// R3-NEXT:      add	w9, w9, w14
+// R3-NEXT:      eor	w12, w12, w13
+// R3-NEXT:      sub	w9, w9, #3
+// R3-NEXT:      add	w12, w12, w15, lsl #1
+// R3-NEXT:      cmp	w9, w2
+// R3-NEXT:      strb	w12, [x0, x11]
+// R3-NEXT:      b.lo	.LBB0_2
+
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/arithmetic/xor-aarch64-ios.c
+++ b/src/test/passes/arithmetic/xor-aarch64-ios.c
@@ -42,12 +42,14 @@
 // R2-NEXT:      ldr     x8, [sp, #16]
 // R2-NEXT:      ldr     w9, [sp, #8]
 // R2-NEXT:      ldrsb   w10, [x8, x9]
-// R2-NEXT:      mov     w8, #35
-// R2-NEXT:      eor     w9, w10, w8
-// R2-NEXT:      and     w11, w10, w8
-// R2-NEXT:      add     w9, w9, w11
-// R2-NEXT:      orn     w8, w8, w10
-// R2-NEXT:      mvn     w10, w10
+// R2-NEXT:      mov     w11, #35
+// R2-NEXT:      add     w8, w10, #35
+// R2-NEXT:      add     w8, w8, #1
+// R2-NEXT:      mov     w9, #-36
+// R2-NEXT:      orn     w9, w9, w10
+// R2-NEXT:      add     w9, w8, w9
+// R2-NEXT:      add     w8, w10, #35
+// R2-NEXT:      orr     w10, w10, w11
 // R2-NEXT:      subs    w11, w8, w10
 // R2-NEXT:      mov     w10, #0
 // R2-NEXT:      subs    w8, w10, w11
@@ -64,44 +66,46 @@
 // R3:       LBB0_2:
 // R3-NEXT:      ldr     x8, [sp, #16]
 // R3-NEXT:      ldr     w9, [sp, #8]
-// R3-NEXT:      ldrsb   w9, [x8, x9]
-// R3-NEXT:      str     w9, [sp, #4]
-// R3-NEXT:      mov     w11, #35
-// R3-NEXT:      bic     w10, w11, w9
-// R3-NEXT:      subs    w8, w9, #35
-// R3-NEXT:      add     w8, w8, w10, lsl #1
-// R3-NEXT:      add     w10, w9, #35
-// R3-NEXT:      orr     w11, w9, w11
-// R3-NEXT:      subs    w10, w10, w11
-// R3-NEXT:      mvn     w10, w10
-// R3-NEXT:      subs    w8, w8, w10
-// R3-NEXT:      subs    w10, w8, #1
-// R3-NEXT:      mvn     w11, w9
-// R3-NEXT:      add     w8, w9, #1
+// R3-NEXT:      ldrsb   w12, [x8, x9]
+// R3-NEXT:      add     w8, w12, #36
+// R3-NEXT:      subs    w9, w8, #1
+// R3-NEXT:      and     w8, w9, #0x1
+// R3-NEXT:      orr     w9, w9, #0x1
+// R3-NEXT:      add     w10, w8, w9
+// R3-NEXT:      mov     w9, #-1
+// R3-NEXT:      mvn     w11, w12
+// R3-NEXT:      add     w8, w12, #1
 // R3-NEXT:      add     w8, w8, w11, lsl #1
-// R3-NEXT:      mov     w11, #-36
-// R3-NEXT:      and     w8, w8, w11
-// R3-NEXT:      add     w8, w8, #35
-// R3-NEXT:      mvn     w11, w9
-// R3-NEXT:      add     w9, w9, #1
-// R3-NEXT:      add     w9, w9, w11, lsl #1
-// R3-NEXT:      mvn     w9, w9
-// R3-NEXT:      add     w8, w8, w9
-// R3-NEXT:      add     w8, w8, #1
-// R3-NEXT:      mvn     w9, w8
-// R3-NEXT:      add     w9, w9, #1
-// R3-NEXT:      bic     w11, w9, w10
-// R3-NEXT:      subs    w9, w10, w9
-// R3-NEXT:      add     w9, w9, w11, lsl #1
-// R3-NEXT:      mvn     w8, w8
-// R3-NEXT:      add     w11, w8, #1
-// R3-NEXT:      add     w8, w10, w11
+// R3-NEXT:      mov     w13, #35
+// R3-NEXT:      and     w8, w8, w13
+// R3-NEXT:      subs    w11, w8, #36
+// R3-NEXT:      and     w8, w10, w11
 // R3-NEXT:      orr     w10, w10, w11
-// R3-NEXT:      subs    w8, w8, w10
-// R3-NEXT:      lsl     w10, w8, #1
-// R3-NEXT:      and     w8, w9, w10
-// R3-NEXT:      orr     w9, w9, w10
-// R3-NEXT:      add     w8, w8, w9
+// R3-NEXT:      add     w11, w8, w10
+// R3-NEXT:      add     w8, w12, #36
+// R3-NEXT:      subs    w10, w8, #1
+// R3-NEXT:      eor     w8, w12, w13
+// R3-NEXT:      and     w12, w12, w13
+// R3-NEXT:      add     w13, w8, w12
+// R3-NEXT:      mov     w12, #0
+// R3-NEXT:      subs    w8, w12, w13
+// R3-NEXT:      eor     w8, w10, w8
+// R3-NEXT:      subs    w12, w12, w13
+// R3-NEXT:      and     w10, w10, w12
+// R3-NEXT:      add     w10, w8, w10, lsl #1
+// R3-NEXT:      mvn     w8, w10
+// R3-NEXT:      add     w12, w8, #1
+// R3-NEXT:      orr     w8, w11, w12
+// R3-NEXT:      and     w12, w11, w12
+// R3-NEXT:      subs    w8, w8, w12
+// R3-NEXT:      mvn     w10, w10
+// R3-NEXT:      add     w12, w10, #1
+// R3-NEXT:      add     w10, w11, w12
+// R3-NEXT:      orr     w11, w11, w12
+// R3-NEXT:      subs    w10, w10, w11
+// R3-NEXT:      eor     w9, w9, w10, lsl #1
+// R3-NEXT:      subs    w8, w8, w9
+// R3-NEXT:      subs    w8, w8, #1
 // R3-NEXT:      ldr     x9, [sp, #24]
 // R3-NEXT:      ldr     w10, [sp, #8]
 // R3-NEXT:      strb    w8, [x9, x10]

--- a/src/test/passes/arithmetic/xor-arm-android.c
+++ b/src/test/passes/arithmetic/xor-arm-android.c
@@ -18,26 +18,19 @@
 
 // R2-LABEL: memcpy_xor:
 // R2:       .LBB0_2:
-// R2-NEXT:      ldrb    r12, [r1, lr]
-// R2-NEXT:      mvn     r3, r12
-// R2-NEXT:      add     r3, r12, r3, lsl #1
-// R2-NEXT:      add     r3, r3, #1
-// R2-NEXT:      mvn     r4, r3
-// R2-NEXT:      orr     r4, r4, #35
-// R2-NEXT:      add     r5, r3, r4
-// R2-NEXT:      and     r4, r12, #93
-// R2-NEXT:      eor     r3, r12, #221
-// R2-NEXT:      add     r3, r3, r4, lsl #1
-// R2-NEXT:      add     r3, r3, r5, lsl #1
-// R2-NEXT:      add     r3, r3, #2
-// R2-NEXT:      strb    r3, [r0, lr]
-// R2-NEXT:      and     r3, lr, #2
-// R2-NEXT:      eor     r5, lr, #2
-// R2-NEXT:      add     r3, r5, r3, lsl #1
-// R2-NEXT:      mvn     r5, r3
-// R2-NEXT:      add     lr, r5, r3, lsl #1
-// R2-NEXT:      cmp     lr, r2
-// R2-NEXT:      blo     .LBB0_2
+// R2-NEXT:      ldrb	r4, [r1], #1
+// R2-NEXT:      mvn	r5, r4
+// R2-NEXT:      orr	r5, r5, r12
+// R2-NEXT:      add	r5, r4, r5
+// R2-NEXT:      add	r5, r5, #36
+// R2-NEXT:      and	r4, r4, #35
+// R2-NEXT:      rsb	r4, r4, #0
+// R2-NEXT:      and	r6, r5, r4
+// R2-NEXT:      eor	r4, r5, r4
+// R2-NEXT:      add	r4, r4, r6, lsl #1
+// R2-NEXT:      strb	r4, [r3], #1
+// R2-NEXT:      subs	lr, lr, #1
+// R2-NEXT:      bne	.LBB0_2
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/arithmetic/xor-x86_64-darwin.c
+++ b/src/test/passes/arithmetic/xor-x86_64-darwin.c
@@ -7,7 +7,7 @@
 
 // RUN:                                        clang -target x86_64-apple-darwin                         -O0 -S %s -o - | FileCheck --check-prefix=R0 %s
 // RUN: env OMVLL_CONFIG=%S/config_rounds_0.py clang -target x86_64-apple-darwin -fpass-plugin=%libOMVLL -O0 -S %s -o - | FileCheck --check-prefix=R0 %s
-// RUN: env OMVLL_CONFIG=%S/config_rounds_2.py clang -target x86_64-apple-darwin -fpass-plugin=%libOMVLL -O0 -S %s -o - | FileCheck --check-prefix=R2 %s
+// RUN: env OMVLL_CONFIG=%S/config_rounds_2.py clang -target x86_64-apple-darwin -fpass-plugin=%libOMVLL -fno-verbose-asm -O0 -S %s -o - | FileCheck --check-prefix=R2 %s
 // RUN: env OMVLL_CONFIG=%S/config_rounds_3.py clang -target x86_64-apple-darwin -fpass-plugin=%libOMVLL -fno-verbose-asm -O0 -S %s -o - | FileCheck --check-prefix=R3 %s
 
 // R0-LABEL: _memcpy_xor:
@@ -20,14 +20,15 @@
 // R2-LABEL: _memcpy_xor:
 // R2:           movsbl  (%rax,%rcx), %eax
 // R2-NEXT:      movl    %eax, %ecx
-// R2-NEXT:      xorl    $35, %ecx
+// R2-NEXT:      addl    $35, %ecx
+// R2-NEXT:      addl    $1, %ecx
 // R2-NEXT:      movl    %eax, %edx
-// R2-NEXT:      andl    $35, %edx
+// R2-NEXT:      xorl    $-1, %edx
+// R2-NEXT:      orl     $-36, %edx
 // R2-NEXT:      addl    %edx, %ecx
 // R2-NEXT:      movl    %eax, %esi
-// R2-NEXT:      xorl    $-1, %esi
-// R2-NEXT:      orl     $35, %esi
-// R2-NEXT:      xorl    $-1, %eax
+// R2-NEXT:      addl    $35, %esi
+// R2-NEXT:      orl     $35, %eax
 // R2-NEXT:      subl    %eax, %esi
 // R2-NEXT:      xorl    %edx, %edx
 // R2-NEXT:      subl    %esi, %edx
@@ -41,62 +42,64 @@
 // R2-NEXT:      movb    %al, %dl
 // R2-NEXT:      movq    -8(%rbp), %rax
 // R2-NEXT:      movl    -24(%rbp), %ecx
+// R2-NEXT:      movb    %dl, (%rax,%rcx)
+// R2-NEXT:      movl    -24(%rbp), %ecx
 
 // R3-LABEL: _memcpy_xor:
 // R3:      movsbl  (%rax,%rcx), %ecx
-// R3-NEXT:      movl    %ecx, -28(%rbp)
 // R3-NEXT:      movl    %ecx, %edx
-// R3-NEXT:      xorl    $-1, %edx
-// R3-NEXT:      andl    $35, %edx
-// R3-NEXT:      movl    %ecx, %eax
-// R3-NEXT:      subl    $35, %eax
-// R3-NEXT:      shll    %edx
+// R3-NEXT:      subl    $-36, %edx
+// R3-NEXT:      subl    $1, %edx
+// R3-NEXT:      movl    %edx, %eax
+// R3-NEXT:      andl    $1, %eax
+// R3-NEXT:      orl     $1, %edx
 // R3-NEXT:      addl    %edx, %eax
-// R3-NEXT:      movl    %ecx, %edx
-// R3-NEXT:      addl    $35, %edx
-// R3-NEXT:      movl    %ecx, %esi
-// R3-NEXT:      orl     $35, %esi
-// R3-NEXT:      subl    %esi, %edx
-// R3-NEXT:      xorl    $-1, %edx
-// R3-NEXT:      subl    %edx, %eax
-// R3-NEXT:      subl    $1, %eax
 // R3-NEXT:      movl    %ecx, %edx
 // R3-NEXT:      xorl    $-1, %edx
 // R3-NEXT:      movl    %ecx, %esi
 // R3-NEXT:      subl    $-1, %esi
 // R3-NEXT:      shll    %edx
 // R3-NEXT:      addl    %edx, %esi
-// R3-NEXT:      andl    $-36, %esi
-// R3-NEXT:      addl    $35, %esi
-// R3-NEXT:      movl    %ecx, %edx
-// R3-NEXT:      xorl    $-1, %edx
-// R3-NEXT:      subl    $-1, %ecx
-// R3-NEXT:      shll    %edx
-// R3-NEXT:      addl    %edx, %ecx
-// R3-NEXT:      xorl    $-1, %ecx
-// R3-NEXT:      addl    %ecx, %esi
-// R3-NEXT:      addl    $1, %esi
+// R3-NEXT:      andl    $35, %esi
+// R3-NEXT:      addl    $-36, %esi
+// R3-NEXT:      movl    %eax, %edx
+// R3-NEXT:      andl    %esi, %edx
+// R3-NEXT:      orl     %esi, %eax
+// R3-NEXT:      addl    %eax, %edx
+// R3-NEXT:      movl    %ecx, %eax
+// R3-NEXT:      subl    $-36, %eax
+// R3-NEXT:      subl    $1, %eax
+// R3-NEXT:      movl    %ecx, %edi
+// R3-NEXT:      xorl    $35, %edi
+// R3-NEXT:      andl    $35, %ecx
+// R3-NEXT:      addl    %ecx, %edi
+// R3-NEXT:      xorl    %ecx, %ecx
+// R3-NEXT:      subl    %edi, %ecx
+// R3-NEXT:      movl    %eax, %esi
+// R3-NEXT:      xorl    %ecx, %esi
+// R3-NEXT:      xorl    %ecx, %ecx
+// R3-NEXT:      subl    %edi, %ecx
+// R3-NEXT:      andl    %ecx, %eax
+// R3-NEXT:      shll    %eax
+// R3-NEXT:      addl    %eax, %esi
 // R3-NEXT:      movl    %esi, %edi
 // R3-NEXT:      xorl    $-1, %edi
 // R3-NEXT:      addl    $1, %edi
-// R3-NEXT:      movl    %eax, %edx
-// R3-NEXT:      xorl    $-1, %edx
-// R3-NEXT:      andl    %edi, %edx
-// R3-NEXT:      movl    %eax, %ecx
-// R3-NEXT:      subl    %edi, %ecx
-// R3-NEXT:      shll    %edx
-// R3-NEXT:      addl    %edx, %ecx
+// R3-NEXT:      movl    %edx, %eax
+// R3-NEXT:      orl     %edi, %eax
+// R3-NEXT:      movl    %edx, %ecx
+// R3-NEXT:      andl    %edi, %ecx
+// R3-NEXT:      subl    %ecx, %eax
 // R3-NEXT:      xorl    $-1, %esi
 // R3-NEXT:      addl    $1, %esi
-// R3-NEXT:      movl    %eax, %edx
-// R3-NEXT:      addl    %esi, %edx
-// R3-NEXT:      orl     %esi, %eax
-// R3-NEXT:      subl    %eax, %edx
-// R3-NEXT:      shll    %edx
-// R3-NEXT:      movl    %ecx, %eax
-// R3-NEXT:      andl    %edx, %eax
-// R3-NEXT:      orl     %edx, %ecx
-// R3-NEXT:      addl    %ecx, %eax
+// R3-NEXT:      movl    %edx, %ecx
+// R3-NEXT:      addl    %esi, %ecx
+// R3-NEXT:      orl     %esi, %edx
+// R3-NEXT:      subl    %edx, %ecx
+// R3-NEXT:      shll    %ecx
+// R3-NEXT:      xorl    $-1, %ecx
+// R3-NEXT:      subl    %ecx, %eax
+// R3-NEXT:      subl    $1, %eax
 // R3-NEXT:      movb    %al, %dl
 // R3-NEXT:      movq    -8(%rbp), %rax
 // R3-NEXT:      movl    -24(%rbp), %ecx

--- a/src/test/passes/arithmetic/xor-x86_64-linux.c
+++ b/src/test/passes/arithmetic/xor-x86_64-linux.c
@@ -23,96 +23,63 @@
 // R1-LABEL: memcpy_xor:
 // R1:       .LBB0_2:
 // R1-NEXT:      movzbl	(%rsi,%rcx), %edx
-// R1-NEXT:      movl	%edx, %r8d
-// R1-NEXT:      notb	%r8b
-// R1-NEXT:      addb	%r8b, %r8b
-// R1-NEXT:      andb	$70, %r8b
-// R1-NEXT:      addb	%dl, %r8b
-// R1-NEXT:      addb	$-35, %r8b
-// R1-NEXT:      movb	%r8b, (%rdi,%rcx)
+// R1-NEXT:      xorb	$35, %dl
+// R1-NEXT:      movb	%dl, (%rdi,%rcx)
 // R1-NEXT:      incq	%rcx
 // R1-NEXT:      cmpq	%rcx, %rax
 // R1-NEXT:      jne	.LBB0_2
 
 // R2-LABEL: memcpy_xor:
 // R2:       .LBB0_2:
-// R2-NEXT:      movl    %eax, %ecx
-// R2-NEXT:      movsbl  (%rsi,%rcx), %r8d
-// R2-NEXT:      movl    %r8d, %r9d
-// R2-NEXT:      notl    %r9d
-// R2-NEXT:      leal    (%r8,%r9,2), %r10d
-// R2-NEXT:      leal    (%r8,%r9,2), %r9d
-// R2-NEXT:      incl    %r9d
-// R2-NEXT:      notl    %r9d
-// R2-NEXT:      orl     $35, %r9d
-// R2-NEXT:      addl    %r10d, %r9d
-// R2-NEXT:      incl    %r9d
-// R2-NEXT:      movl    %r8d, %r10d
-// R2-NEXT:      xorl    $221, %r10d
-// R2-NEXT:      andl    $93, %r8d
-// R2-NEXT:      leal    (%r10,%r8,2), %r8d
-// R2-NEXT:      leal    (%r8,%r9,2), %r8d
-// R2-NEXT:      addb    $2, %r8b
-// R2-NEXT:      movb    %r8b, (%rdi,%rcx)
-// R2-NEXT:      movl    %eax, %ecx
-// R2-NEXT:      xorl    $2, %ecx
-// R2-NEXT:      andl    $2, %eax
-// R2-NEXT:      leal    (%rcx,%rax,2), %eax
-// R2-NEXT:      movl    %eax, %ecx
-// R2-NEXT:      notl    %ecx
-// R2-NEXT:      leal    (%rcx,%rax,2), %eax
-// R2-NEXT:      cmpl    %edx, %eax
-// R2-NEXT:      jb      .LBB0_2
+// R2-NEXT:    	 movsbl	(%rsi,%rcx), %edx
+// R2-NEXT:    	 movl	%edx, %r8d
+// R2-NEXT:    	 notl	%r8d
+// R2-NEXT:    	 orl	$-36, %r8d
+// R2-NEXT:    	 addl	%edx, %r8d
+// R2-NEXT:    	 addl	$36, %r8d
+// R2-NEXT:    	 andl	$35, %edx
+// R2-NEXT:    	 negl	%edx
+// R2-NEXT:    	 movl	%r8d, %r9d
+// R2-NEXT:    	 xorl	%edx, %r9d
+// R2-NEXT:    	 andl	%r8d, %edx
+// R2-NEXT:    	 leal	(%r9,%rdx,2), %edx
+// R2-NEXT:    	 movb	%dl, (%rdi,%rcx)
+// R2-NEXT:    	 incq	%rcx
+// R2-NEXT:    	 cmpq	%rcx, %rax
+// R2-NEXT:    	 jne	.LBB0_2
 
 // R3-LABEL: memcpy_xor:
 // R3:       .LBB0_2:
-// R3-NEXT:      movl    %eax, %ecx
-// R3-NEXT:      movsbl  (%rsi,%rcx), %r9d
-// R3-NEXT:      movl    %r9d, %r8d
-// R3-NEXT:      notl    %r8d
-// R3-NEXT:      leal    (%r9,%r8,2), %r11d
-// R3-NEXT:      leal    (%r9,%r9), %ebx
-// R3-NEXT:      movl    %ebx, %r10d
-// R3-NEXT:      notl    %r10d
-// R3-NEXT:      andl    $186, %r10d
-// R3-NEXT:      orl     $2147483613, %r8d
-// R3-NEXT:      addl    %r9d, %r8d
-// R3-NEXT:      addl    %r9d, %r10d
-// R3-NEXT:      xorl    $1, %r9d
-// R3-NEXT:      andl    $2, %ebx
-// R3-NEXT:      addl    %r9d, %ebx
-// R3-NEXT:      leal    (%rbx,%r11,2), %r9d
-// R3-NEXT:      leal    (%rbx,%r11,2), %r11d
-// R3-NEXT:      addl    $2, %r11d
-// R3-NEXT:      notl    %r11d
-// R3-NEXT:      leal    (%r9,%r11,2), %ebx
-// R3-NEXT:      addl    $2, %ebx
-// R3-NEXT:      leal    (%r9,%r11,2), %r9d
-// R3-NEXT:      addl    $3, %r9d
-// R3-NEXT:      notl    %r9d
-// R3-NEXT:      orl     $-36, %r9d
-// R3-NEXT:      addl    %ebx, %r9d
-// R3-NEXT:      addl    $37, %r9d
-// R3-NEXT:      notl    %ebx
-// R3-NEXT:      movl    %r9d, %r11d
-// R3-NEXT:      xorl    %ebx, %r11d
-// R3-NEXT:      andl    %r9d, %ebx
-// R3-NEXT:      addl    %r11d, %r8d
-// R3-NEXT:      leal    (%r8,%rbx,2), %r8d
-// R3-NEXT:      leal    (%r10,%r8,2), %r8d
-// R3-NEXT:      addb    $37, %r8b
-// R3-NEXT:      movb    %r8b, (%rdi,%rcx)
-// R3-NEXT:      leal    (%rax,%rax), %ecx
-// R3-NEXT:      andl    $4, %ecx
-// R3-NEXT:      leal    (%rax,%rcx), %r8d
-// R3-NEXT:      xorl    $4, %ecx
-// R3-NEXT:      addl    %r8d, %ecx
-// R3-NEXT:      addl    $-2, %ecx
-// R3-NEXT:      orl     $1, %ecx
-// R3-NEXT:      orl     $-2, %eax
-// R3-NEXT:      addl    %ecx, %eax
-// R3-NEXT:      cmpl    %edx, %eax
-// R3-NEXT:      jb      .LBB0_2
+// R3-NEXT:      movl	%eax, %ecx
+// R3-NEXT:      movsbl	(%rsi,%rcx), %r8d
+// R3-NEXT:      movl	%r8d, %r9d
+// R3-NEXT:      notl	%r9d
+// R3-NEXT:      leal	(%r8,%r9,2), %r9d
+// R3-NEXT:      incl	%r9d
+// R3-NEXT:      orl	$-36, %r9d
+// R3-NEXT:      addl	%r8d, %r9d
+// R3-NEXT:      addl	$36, %r9d
+// R3-NEXT:      leal	35(%r8), %r10d
+// R3-NEXT:      orl	$35, %r8d
+// R3-NEXT:      negl	%r8d
+// R3-NEXT:      movl	%r10d, %r11d
+// R3-NEXT:      xorl	%r8d, %r11d
+// R3-NEXT:      andl	%r10d, %r8d
+// R3-NEXT:      leal	(%r11,%r8,2), %r8d
+// R3-NEXT:      negl	%r8d
+// R3-NEXT:      movl	%r9d, %r10d
+// R3-NEXT:      xorl	%r8d, %r10d
+// R3-NEXT:      andl	%r9d, %r8d
+// R3-NEXT:      leal	(%r10,%r8,2), %r8d
+// R3-NEXT:      movb	%r8b, (%rdi,%rcx)
+// R3-NEXT:      leal	(%rax,%rax), %ecx
+// R3-NEXT:      andl	$4, %ecx
+// R3-NEXT:      addl	%ecx, %eax
+// R3-NEXT:      xorl	$4, %ecx
+// R3-NEXT:      addl	%ecx, %eax
+// R3-NEXT:      addl	$-3, %eax
+// R3-NEXT:      cmpl	%edx, %eax
+// R3-NEXT:      jb	.LBB0_2
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/cfg-flattening/basic-aarch64-android.c
+++ b/src/test/passes/cfg-flattening/basic-aarch64-android.c
@@ -10,20 +10,20 @@
 // Check for jump table targets setup at the beginning of the function.
 
 // FLAT-ANDROID-LABEL:    check_password:
-// FLAT-ANDROID:            movk    w4, #50251, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w5, #17606, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w6, #17961, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w7, #22555, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w19, #17606, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w20, #17961, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w21, #47252, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w22, #22555, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w23, #49424, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w24, #26706, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w25, #32064, lsl #16
-// FLAT-ANDROID-NEXT:       movk    w26, #50251, lsl #16
-// FLAT-ANDROID-NEXT:       stur    w11, [x29, #-4]
-// FLAT-ANDROID-NEXT:       b       .LBB0_2
+// FLAT-ANDROID:            movk	w4, #47507, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w5, #3652, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w6, #7153, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w7, #25844, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w19, #29878, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w20, #14846, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w21, #25844, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w22, #3652, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w23, #31029, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w24, #31029, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w25, #60668, lsl #16
+// FLAT-ANDROID-NEXT:       movk	w26, #29878, lsl #16
+// FLAT-ANDROID-NEXT:       stur	w11, [x29, #-4]
+// FLAT-ANDROID-NEXT:       b	.LBB0_2
 
 int check_password(const char *passwd, unsigned len) {
   if (len != 5) {

--- a/src/test/passes/cfg-flattening/basic-aarch64-ios.c
+++ b/src/test/passes/cfg-flattening/basic-aarch64-ios.c
@@ -11,22 +11,22 @@
 // Check for jump table targets setup at the beginning of the function.
 
 // FLAT-IOS-LABEL:        check_password:
-// FLAT-IOS:                mov     w19, #53399
-// FLAT-IOS-NEXT:           movk    w19, #26689, lsl #16
-// FLAT-IOS-NEXT:           mov     w20, #41365
-// FLAT-IOS-NEXT:           movk    w20, #6014, lsl #16
-// FLAT-IOS-NEXT:           mov     w21, #52826
-// FLAT-IOS-NEXT:           movk    w21, #7648, lsl #16
-// FLAT-IOS-NEXT:           mov     w22, #35197
-// FLAT-IOS-NEXT:           movk    w22, #63120, lsl #16
-// FLAT-IOS-NEXT:           mov     w23, #53606
-// FLAT-IOS-NEXT:           movk    w23, #26689, lsl #16
-// FLAT-IOS-NEXT:           mov     w24, #52579
-// FLAT-IOS-NEXT:           movk    w24, #7648, lsl #16
-// FLAT-IOS-NEXT:           mov     w25, #44088
-// FLAT-IOS-NEXT:           movk    w25, #2345, lsl #16
-// FLAT-IOS-NEXT:           mov     w26, #10794
-// FLAT-IOS-NEXT:           movk    w26, #56152, lsl #16
+// FLAT-IOS:                mov     w19, #13230
+// FLAT-IOS-NEXT:           movk    w19, #29878, lsl #16
+// FLAT-IOS-NEXT:           mov     w20, #61392
+// FLAT-IOS-NEXT:           movk    w20, #14846, lsl #16
+// FLAT-IOS-NEXT:           mov     w21, #25040
+// FLAT-IOS-NEXT:           movk    w21, #25844, lsl #16
+// FLAT-IOS-NEXT:           mov     w22, #32794
+// FLAT-IOS-NEXT:           movk    w22, #3652, lsl #16
+// FLAT-IOS-NEXT:           mov     w23, #49474
+// FLAT-IOS-NEXT:           movk    w23, #31029, lsl #16
+// FLAT-IOS-NEXT:           mov     w24, #49304
+// FLAT-IOS-NEXT:           movk    w24, #31029, lsl #16
+// FLAT-IOS-NEXT:           mov     w25, #26434
+// FLAT-IOS-NEXT:           movk    w25, #60668, lsl #16
+// FLAT-IOS-NEXT:           mov     w26, #13231
+// FLAT-IOS-NEXT:           movk    w26, #29878, lsl #16
 // FLAT-IOS-NEXT:           b       LBB0_4
 
 int check_password(const char *passwd, unsigned len) {

--- a/src/test/passes/cfg-flattening/basic-arm-android.c
+++ b/src/test/passes/cfg-flattening/basic-arm-android.c
@@ -22,40 +22,40 @@
 // NO-FLAT-NEXT:    beq	.LBB0_4
 
 // FLAT-LABEL:    check_password:
-// FLAT-ARM:            str     r1, [sp, #4]
-// FLAT-ARM:            ldr     r1, .LCPI0_0
-// FLAT-ARM:            str     r1, [sp, #16]
-// FLAT-ARM:            ldr     lr, .LCPI0_1
-// FLAT-ARM:            ldr     r2, .LCPI0_2
-// FLAT-ARM:            ldr     r4, .LCPI0_3
-// FLAT-ARM:            ldr     r12, .LCPI0_10
-// FLAT-ARM:            ldr     r5, .LCPI0_12
-// FLAT-ARM:            ldr     r3, .LCPI0_11
-// FLAT-ARM:            ldr     r8, .LCPI0_4
-// FLAT-ARM:            ldr     r10, .LCPI0_8
-// FLAT-ARM:            b       .LBB0_2
+// FLAT-ARM:          	str	r1, [sp, #4]
+// FLAT-ARM-NEXT:     	ldr	r1, .LCPI0_0
+// FLAT-ARM-NEXT:     	str	r1, [sp, #16]
+// FLAT-ARM-NEXT:     	ldr	r8, .LCPI0_1
+// FLAT-ARM-NEXT:     	ldr	r2, .LCPI0_2
+// FLAT-ARM-NEXT:     	ldr	r10, .LCPI0_3
+// FLAT-ARM-NEXT:     	ldr	lr, .LCPI0_9
+// FLAT-ARM-NEXT:     	ldr	r3, .LCPI0_13
+// FLAT-ARM-NEXT:     	ldr	r4, .LCPI0_10
+// FLAT-ARM-NEXT:     	ldr	r5, .LCPI0_11
+// FLAT-ARM-NEXT:     	ldr	r9, .LCPI0_4
+// FLAT-ARM-NEXT:     	b	.LBB0_2
 
-// FLAT-THUMB:          str     r1, [sp, #4]
-// FLAT-THUMB-NEXT:     movw    r1, #3951
-// FLAT-THUMB-NEXT:     movt    r1, #15636
-// FLAT-THUMB-NEXT:     str     r1, [sp, #16]
-// FLAT-THUMB-NEXT:     movw    lr, #52532
-// FLAT-THUMB-NEXT:     movt    lr, #26706
-// FLAT-THUMB-NEXT:     movw    r2, #53269
-// FLAT-THUMB-NEXT:     movt    r2, #45387
-// FLAT-THUMB-NEXT:     movw    r4, #8047
-// FLAT-THUMB-NEXT:     movt    r4, #17606
-// FLAT-THUMB-NEXT:     movw    r12, #29561
-// FLAT-THUMB-NEXT:     movt    r12, #50251
-// FLAT-THUMB-NEXT:     movw    r5, #30275
-// FLAT-THUMB-NEXT:     movt    r5, #47252
-// FLAT-THUMB-NEXT:     movw    r3, #29562
-// FLAT-THUMB-NEXT:     movt    r3, #50251
-// FLAT-THUMB-NEXT:     movw    r8, #1332
-// FLAT-THUMB-NEXT:     movt    r8, #22555
-// FLAT-THUMB-NEXT:     movw    r10, #8048
-// FLAT-THUMB-NEXT:     movt    r10, #17606
-// FLAT-THUMB-NEXT:     b       .LBB0_2
+// FLAT-THUMB:        	str	r1, [sp, #4]
+// FLAT-THUMB-NEXT:   	movw	r1, #17966
+// FLAT-THUMB-NEXT:   	movt	r1, #31462
+// FLAT-THUMB-NEXT:   	str	r1, [sp, #16]
+// FLAT-THUMB-NEXT:   	movw	r8, #61194
+// FLAT-THUMB-NEXT:   	movt	r8, #14846
+// FLAT-THUMB-NEXT:   	movw	r2, #13093
+// FLAT-THUMB-NEXT:   	movt	r2, #29878
+// FLAT-THUMB-NEXT:   	movw	r10, #61391
+// FLAT-THUMB-NEXT:   	movt	r10, #14846
+// FLAT-THUMB-NEXT:   	movw	lr, #26503
+// FLAT-THUMB-NEXT:   	movt	lr, #60668
+// FLAT-THUMB-NEXT:   	movw	r3, #53796
+// FLAT-THUMB-NEXT:   	movt	r3, #37211
+// FLAT-THUMB-NEXT:   	movw	r4, #26504
+// FLAT-THUMB-NEXT:   	movt	r4, #60668
+// FLAT-THUMB-NEXT:   	movw	r5, #32960
+// FLAT-THUMB-NEXT:   	movt	r5, #3652
+// FLAT-THUMB-NEXT:   	movw	r9, #13230
+// FLAT-THUMB-NEXT:   	movt	r9, #29878
+// FLAT-THUMB-NEXT:   	b	.LBB0_2
 
 int check_password(const char* passwd, unsigned len) {
   if (len != 5) {

--- a/src/test/passes/opaque-constants/basic-aarch64-ios.ll
+++ b/src/test/passes/opaque-constants/basic-aarch64-ios.ll
@@ -32,7 +32,7 @@ define i32 @opaque_constants() {
 ; CHECK-O0-NEXT:  %9 = sub i32 %7, %8, !obf !0
 ; CHECK-O0-NEXT:  store i32 %9, ptr %stack.0, align 4
 ; CHECK-O0-NEXT:  %10 = load volatile i32, ptr %opaque.t2, align 4
-; CHECK-O0-NEXT:  %11 = xor i32 49, %10, !obf !0
+; CHECK-O0-NEXT:  %11 = xor i32 29, %10, !obf !0
 ; CHECK-O0-NEXT:  %12 = xor i32 %11, %10, !obf !0
 ; CHECK-O0-NEXT:  %13 = or i32 %12, 1, !obf !0
 ; CHECK-O0-NEXT:  %14 = and i32 %13, 1, !obf !0


### PR DESCRIPTION
Prefer the use of std::mt19937_64 for random number generation needs instead of std::rand.