### PR TITLE
StringEncoding: Support Objective-C strings

### DIFF
--- a/src/include/omvll/passes/string-encoding/StringEncoding.hpp
+++ b/src/include/omvll/passes/string-encoding/StringEncoding.hpp
@@ -58,25 +58,27 @@ struct StringEncoding : llvm::PassInfoMixin<StringEncoding> {
   bool injectDecoding(llvm::Instruction &I, llvm::Use &Op,
                       llvm::GlobalVariable &G,
                       llvm::ConstantDataSequential &Data,
-                      const EncodingInfo &Info);
+                      const EncodingInfo &Info, bool IsCFStringBacking = false);
   bool injectDecodingLocally(llvm::Instruction &I, llvm::Use &Op,
                              llvm::GlobalVariable &G,
                              llvm::ConstantDataSequential &Data,
-                             const EncodingInfo &Info);
+                             const EncodingInfo &Info,
+                             bool IsCFStringBacking = false);
   llvm::CallInst *createDecodingTrampoline(
       llvm::GlobalVariable &G, llvm::Use &EncPtr, llvm::Instruction *NewPt,
       uint64_t KeyValI64, uint64_t Size, const StringEncoding::EncodingInfo &EI,
-      bool IsLocalToFunction = false);
+      bool IsLocalToFunction = false, bool IsCFStringBacking = false);
   bool process(llvm::Instruction &I, llvm::Use &Op, llvm::GlobalVariable &G,
-               llvm::ConstantDataSequential &Data, StringEncodingOpt &Opt);
+               llvm::ConstantDataSequential &Data, StringEncodingOpt &Opt,
+               bool IsCFStringBacking = false);
   bool processReplace(llvm::Use &Op, llvm::GlobalVariable &G,
                       llvm::ConstantDataSequential &Data,
                       StringEncOptReplace &Rep);
   bool processGlobal(llvm::Use &Op, llvm::GlobalVariable &G,
                      llvm::ConstantDataSequential &Data);
   bool processLocal(llvm::Instruction &I, llvm::Use &Op,
-                    llvm::GlobalVariable &G,
-                    llvm::ConstantDataSequential &Data);
+                    llvm::GlobalVariable &G, llvm::ConstantDataSequential &Data,
+                    bool IsCFStringBacking = false);
   bool processArrayOfStrings(llvm::Instruction &CurrentI, llvm::Use &Op,
                              llvm::ConstantArray *CA, llvm::GlobalVariable *GV,
                              ObfuscationConfig &);

--- a/src/passes/string-encoding/StringEncoding.cpp
+++ b/src/passes/string-encoding/StringEncoding.cpp
@@ -116,7 +116,7 @@ materializeConstantExpression(Instruction *Point, ConstantExpr *CE) {
 CallInst *StringEncoding::createDecodingTrampoline(
     GlobalVariable &G, Use &EncPtr, Instruction *NewPt, uint64_t KeyValI64,
     uint64_t Size, const StringEncoding::EncodingInfo &EI,
-    bool IsLocalToFunction) {
+    bool IsLocalToFunction, bool IsCFStringBacking) {
   Module *M = NewPt->getModule();
   LLVMContext &Ctx = NewPt->getContext();
 
@@ -167,7 +167,7 @@ CallInst *StringEncoding::createDecodingTrampoline(
   Value *Input = IRB.CreateBitCast(&G, IRB.getPtrTy());
   Value *Output = Input;
 
-  if (IsLocalToFunction)
+  if (IsLocalToFunction && !IsCFStringBacking)
     Output = ClearBuffer;
 
   auto *NewF =
@@ -240,7 +240,9 @@ CallInst *StringEncoding::createDecodingTrampoline(
   CI = IRB.CreateCall(Wrapper->getFunctionType(), Wrapper,
                       {NeedDecode, Output, Input, OpaqueKey, VStrSize});
 
-  if (auto *CE = dyn_cast<ConstantExpr>(EncPtr)) {
+  if (IsCFStringBacking) {
+    // Do not patch Op -- it points to unnamed_cfstring struct
+  } else if (auto *CE = dyn_cast<ConstantExpr>(EncPtr)) {
     auto [First, Last] = materializeConstantExpression(NewPt, CE);
     assert(((First != Last) ||
             (isa<GetElementPtrInst>(First) || isa<PtrToIntInst>(First))) &&
@@ -330,10 +332,11 @@ bool StringEncoding::processArrayOfStrings(Instruction &CurrentI, Use &Op,
   bool IsLocal = false;
   for (GlobalVariable *S : EmbeddedStrings) {
     auto *Data = cast<ConstantDataSequential>(S->getInitializer());
-    if (EncodingInfo *EI = getEncoding(*S);
-        EI && EI->Type == EncodingTy::Local) {
-      IsLocal = true;
-      Changed |= injectDecoding(CurrentI, Op, *S, *Data, *EI);
+    if (EncodingInfo *EI = getEncoding(*S)) {
+      if (EI->Type == EncodingTy::Local) {
+        IsLocal = true;
+        Changed |= injectDecoding(CurrentI, Op, *S, *Data, *EI);
+      }
       continue;
     }
 
@@ -384,6 +387,20 @@ bool StringEncoding::encodeStrings(Function &F, ObfuscationConfig &UserConfig) {
       if (!G || !G->hasInitializer())
         continue;
 
+      bool IsCFStringBacking = false;
+      if (auto *CS = dyn_cast<ConstantStruct>(G->getInitializer())) {
+        if (CS->getNumOperands() == 4) {
+          Value *StringPtr = CS->getOperand(2);
+          if (auto *NestedGV =
+                  dyn_cast<GlobalVariable>(StringPtr->stripPointerCasts())) {
+            G = NestedGV;
+            IsCFStringBacking = true;
+            // Op still points at the cfstring struct
+            // we must not rewrite it in the trampoline
+          }
+        }
+      }
+
       // Process array of strings pointer.
       // TODO: Should properly refactor `encodeStrings` instead of having a
       // dedicated helper here.
@@ -430,7 +447,7 @@ bool StringEncoding::encodeStrings(Function &F, ObfuscationConfig &UserConfig) {
       if (EncodingInfo *EI = getEncoding(*G)) {
         // The global variable is already encoded.
         // Let's check if we should insert a decoding stub.
-        Changed |= injectDecoding(I, Op, *G, *Data, *EI);
+        Changed |= injectDecoding(I, Op, *G, *Data, *EI, IsCFStringBacking);
         continue;
       }
 
@@ -451,7 +468,8 @@ bool StringEncoding::encodeStrings(Function &F, ObfuscationConfig &UserConfig) {
         continue;
 
       SINFO("[{}] Processing string {}", name(), Data->getAsCString());
-      Changed |= process(I, *ActualOp, *G, *Data, *EncInfoOpt);
+      Changed |=
+          process(I, *ActualOp, *G, *Data, *EncInfoOpt, IsCFStringBacking);
     }
   }
 
@@ -504,21 +522,22 @@ PreservedAnalyses StringEncoding::run(Module &M, ModuleAnalysisManager &MAM) {
 
 bool StringEncoding::injectDecoding(Instruction &I, Use &Op, GlobalVariable &G,
                                     ConstantDataSequential &Data,
-                                    const StringEncoding::EncodingInfo &Info) {
+                                    const StringEncoding::EncodingInfo &Info,
+                                    bool IsCFStringBacking) {
   switch (Info.Type) {
   case EncodingTy::None:
   case EncodingTy::Replace:
   case EncodingTy::Global:
     return false;
   case EncodingTy::Local:
-    return injectDecodingLocally(I, Op, G, Data, Info);
+    return injectDecodingLocally(I, Op, G, Data, Info, IsCFStringBacking);
   }
   llvm_unreachable("Unhandled case");
 }
 
 bool StringEncoding::injectDecodingLocally(
     Instruction &I, Use &Op, GlobalVariable &G, ConstantDataSequential &Data,
-    const StringEncoding::EncodingInfo &Info) {
+    const StringEncoding::EncodingInfo &Info, bool IsCFStringBacking) {
   auto *Key = std::get_if<KeyIntTy>(&Info.Key);
   if (!Key)
     fatalError("String stack decoding loop is expecting a buffer as a key! ");
@@ -526,18 +545,21 @@ bool StringEncoding::injectDecodingLocally(
   uint64_t StrSz = Data.getRawDataValues().size();
   SDEBUG("Key for 0x{:010x}", *Key);
 
-  auto *Callee = createDecodingTrampoline(G, Op, &I, *Key, StrSz, Info, true);
+  auto *Callee = createDecodingTrampoline(G, Op, &I, *Key, StrSz, Info, true,
+                                          IsCFStringBacking);
   ToInline.push_back(Callee);
   return true;
 }
 
 bool StringEncoding::process(Instruction &I, Use &Op, GlobalVariable &G,
                              ConstantDataSequential &Data,
-                             StringEncodingOpt &Opt) {
+                             StringEncodingOpt &Opt, bool IsCFStringBacking) {
   bool Changed = std::visit(
       overloaded{
           [&](StringEncOptSkip &) { return false; },
-          [&](StringEncOptLocal &) { return processLocal(I, Op, G, Data); },
+          [&](StringEncOptLocal &) {
+            return processLocal(I, Op, G, Data, IsCFStringBacking);
+          },
           [&](StringEncOptGlobal &) { return processGlobal(Op, G, Data); },
           [&](StringEncOptReplace &Rep) {
             return processReplace(Op, G, Data, Rep);
@@ -604,7 +626,8 @@ bool StringEncoding::processGlobal(Use &Op, GlobalVariable &G,
 #if LLVM_VERSION_MAJOR > 18
   unsigned GlobalIDHashVal = xxh3_64bits(G.getGlobalIdentifier());
 #else
-  unsigned GlobalIDHashVal = stable_hash_combine_string(G.getGlobalIdentifier());
+  unsigned GlobalIDHashVal =
+      stable_hash_combine_string(G.getGlobalIdentifier());
 #endif
   unsigned HashCombinedVal = stable_hash_combine(GlobalIDHashVal, StrSz, Key);
   std::string Name = CtorPrefixName + utostr(HashCombinedVal);
@@ -661,7 +684,8 @@ void StringEncoding::annotateRoutine(Module &M) {
 }
 
 bool StringEncoding::processLocal(Instruction &I, Use &Op, GlobalVariable &G,
-                                  ConstantDataSequential &Data) {
+                                  ConstantDataSequential &Data,
+                                  bool IsCFStringBacking) {
   LLVMContext &Ctx = I.getContext();
   StringRef Str = Data.getRawDataValues();
   uint64_t StrSz = Str.size();
@@ -682,7 +706,7 @@ bool StringEncoding::processLocal(Instruction &I, Use &Op, GlobalVariable &G,
 
   auto It = GVarEncInfo.insert({&G, std::move(EI)}).first;
   return injectDecodingLocally(I, Op, G, *cast<ConstantDataSequential>(StrEnc),
-                               It->getSecond());
+                               It->getSecond(), IsCFStringBacking);
 }
 
 } // end namespace omvll


### PR DESCRIPTION
NSString literals are backed by a __NSConstantString_tag struct whose data pointer references a plain .str global. The pass now traverses the struct to encrypt the backing global directly.