### PR TITLE
omvll_config: Replace vector with set in PassPhases

### DIFF
--- a/src/core/omvll_config.cpp
+++ b/src/core/omvll_config.cpp
@@ -7,32 +7,12 @@
 #include <unordered_map>
 
 #include "omvll/omvll_config.hpp"
-#include "omvll/passes.hpp"
 
 namespace omvll {
 
 OMVLLConfig Config;
 
 void initDefaultConfig() {
-  Config.Passes = {
-      AntiHook::name().str(),
-      StringEncoding::name().str(),
-
-      OpaqueFieldAccess::name().str(),
-      ControlFlowFlattening::name().str(),
-      BreakControlFlow::name().str(),
-
-      OpaqueConstants::name().str(),
-      Arithmetic::name().str(),
-      IndirectBranch::name().str(),
-      IndirectCall::name().str(),
-      BasicBlockDuplicate::name().str(),
-      FunctionOutline::name().str(),
-
-      // Last pass.
-      Cleaning::name().str(),
-  };
-
   Config.PassPhases.clear();
 
   Config.Cleaning = true;
@@ -72,10 +52,7 @@ bool hasPhase(const std::string &PassName, Phase P) {
   auto It = Config.PassPhases.find(*MaybePass);
   if (It == Config.PassPhases.end())
     return P == Phase::Early;
-  for (Phase Ph : It->second)
-    if (Ph == P)
-      return true;
-  return false;
+  return It->second.count(P) > 0;
 }
 
 } // end namespace omvll

--- a/src/core/python/PyConfig.cpp
+++ b/src/core/python/PyConfig.cpp
@@ -83,18 +83,25 @@ void OMVLLCtor(py::module_ &m) {
     Enum representing all available obfuscation passes.
 
     Use values of this enum as keys in :attr:`omvll.config.pass_phases`.
+
+    To obtain the full list of passes in their execution order, use:
+
+    .. code-block:: python
+
+        list(omvll.Pass)
+
     )delim")
       .value("AntiHook",              Pass::AntiHook)
+      .value("FunctionOutline",       Pass::FunctionOutline)
       .value("StringEncoding",        Pass::StringEncoding)
       .value("OpaqueFieldAccess",     Pass::OpaqueFieldAccess)
+      .value("BasicBlockDuplicate",   Pass::BasicBlockDuplicate)
       .value("ControlFlowFlattening", Pass::ControlFlowFlattening)
       .value("BreakControlFlow",      Pass::BreakControlFlow)
       .value("OpaqueConstants",       Pass::OpaqueConstants)
       .value("Arithmetic",            Pass::Arithmetic)
-      .value("IndirectBranch",        Pass::IndirectBranch)
       .value("IndirectCall",          Pass::IndirectCall)
-      .value("BasicBlockDuplicate",   Pass::BasicBlockDuplicate)
-      .value("FunctionOutline",       Pass::FunctionOutline)
+      .value("IndirectBranch",        Pass::IndirectBranch)
       .value("Cleaning",              Pass::Cleaning);
 
   py::class_<OMVLLConfig>(m, "OMVLLConfig",
@@ -103,18 +110,6 @@ void OMVLLCtor(py::module_ &m) {
 
     It can be accessed through the global :attr:`omvll.config` attribute
     )delim")
-      .def_readwrite("passes", &OMVLLConfig::Passes,
-                     R"delim(
-                   This **ordered** list contains the sequence of the obfuscation passes
-                   that must be used.
-                   It should not be modified unless you know what you do.
-
-                   This attribute is set by default to these values:
-
-                   |omvll-passes|
-
-                   )delim")
-
       .def_readwrite("inline_jni_wrappers", &OMVLLConfig::InlineJniWrappers,
                      R"delim(
                    This boolean attribute is used to force inlining JNI C++ wrapper.
@@ -203,9 +198,9 @@ void OMVLLCtor(py::module_ &m) {
                     .. code-block:: python
 
                         omvll.config.pass_phases = {
-                            omvll.Pass.Arithmetic:        [omvll.Phase.Early],
-                            omvll.Pass.BreakControlFlow:  [omvll.Phase.Last],
-                            omvll.Pass.StringEncoding:    [omvll.Phase.Early, omvll.Phase.Last],
+                            omvll.Pass.Arithmetic:        {omvll.Phase.Early},
+                            omvll.Pass.BreakControlFlow:  {omvll.Phase.Last},
+                            omvll.Pass.StringEncoding:    {omvll.Phase.Early, omvll.Phase.Last},
                         }
 
                     )delim");

--- a/src/include/omvll/omvll_config.hpp
+++ b/src/include/omvll/omvll_config.hpp
@@ -6,6 +6,7 @@
 //
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -32,8 +33,7 @@ enum class Pass {
 };
 
 struct OMVLLConfig {
-  std::vector<std::string> Passes;
-  std::map<Pass, std::vector<Phase>> PassPhases;
+  std::map<Pass, std::set<Phase>> PassPhases;
   std::vector<std::string> GlobalModuleExclude;
   std::vector<std::string> GlobalFunctionExclude;
   std::string OutputFolder;


### PR DESCRIPTION
Replace std::vector<Phase> with std::set<Phase> in PassPhases to prevent duplicate phase entries per pass.

Remove the Passes field from OMVLLConfig — it was written but never read in C++. Python users can now enumerate passes in execution order via list(omvll.Pass).

Simplify hasPhase() to use set::count() instead of a manual linear scan.

Reorder Pass enum registrations in Python bindings to match the actual execution order defined in getPassRegistry().

Update Python docstrings and examples accordingly.