### PR TITLE
StringEncoding: Fix bug with denotePHINode

### DIFF
--- a/src/passes/string-encoding/StringEncoding.cpp
+++ b/src/passes/string-encoding/StringEncoding.cpp
@@ -380,9 +380,36 @@ bool StringEncoding::processArrayOfStrings(Instruction &CurrentI, Use &Op,
   return Changed;
 }
 
+static bool hasEligibleGlobal(const Instruction &I) {
+  for (const Use &Op : I.operands()) {
+    auto *G = dyn_cast<GlobalVariable>(Op->stripPointerCasts());
+    if (!G)
+      if (auto *CE = dyn_cast<ConstantExpr>(Op.get()))
+        G = extractGlobalVariable(CE);
+    if (!G || !G->hasInitializer())
+      continue;
+    if (isEligible(*G))
+      return true;
+    const Constant *Init = G->getInitializer();
+    if (const auto *StrippedGV = dyn_cast<GlobalVariable>(Init->stripPointerCasts()))
+      if (isEligible(*StrippedGV))
+        return true;
+    if (const auto *CE = dyn_cast<ConstantExpr>(Init))
+      if (auto *Nested = extractGlobalVariable(const_cast<ConstantExpr *>(CE)))
+        if (isEligible(*Nested))
+          return true;
+  }
+  return false;
+}
+
 bool StringEncoding::encodeStrings(Function &F, ObfuscationConfig &UserConfig) {
   bool Changed = false;
   llvm::Module *M = F.getParent();
+
+  if (!llvm::any_of(instructions(F), hasEligibleGlobal))
+    return false;
+
+  demotePHINode(F);
 
   for (Instruction &I : make_early_inc_range(instructions(F))) {
     assert(!isa<PHINode>(I) && "Found phi previously demoted?");
@@ -488,7 +515,6 @@ PreservedAnalyses StringEncoding::run(Module &M, ModuleAnalysisManager &MAM) {
     if (isFunctionGloballyExcluded(&F) || F.empty() || F.isDeclaration())
       continue;
 
-    demotePHINode(F);
     ToVisit.emplace_back(&F);
   }
 

--- a/src/test/passes/function-outline/basic-aarch64-ios.ll
+++ b/src/test/passes/function-outline/basic-aarch64-ios.ll
@@ -15,16 +15,13 @@ define i32 @function_outline(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[USE_LOC:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[SUM:%.*]] = add i32 [[X]], [[Y]]
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[X]], [[Y]]
-; CHECK-NEXT:    [[RET_REG2MEM:%.*]] = alloca i32, align 4
-; CHECK-NEXT:    store i32 [[SUM]], ptr [[RET_REG2MEM]], align 4
 ; CHECK-NEXT:    br i1 [[CMP]], label %[[CODEREPL:.*]], label %[[EXIT:.*]]
 ; CHECK:       [[CODEREPL]]:
 ; CHECK-NEXT:    call void @function_outline.bb(i32 [[SUM]], ptr [[USE_LOC]])
 ; CHECK-NEXT:    [[USE_RELOAD:%.*]] = load i32, ptr [[USE_LOC]], align 4
-; CHECK-NEXT:    store i32 [[USE_RELOAD]], ptr [[RET_REG2MEM]], align 4
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    [[RET_RELOAD:%.*]] = load i32, ptr [[RET_REG2MEM]], align 4
+; CHECK-NEXT:    [[RET_RELOAD:%.*]] = phi i32 [ [[USE_RELOAD]], [[CODEREPL:.*]] ], [ [[SUM]], [[ENTRY:.*]] ]
 ; CHECK-NEXT:    ret i32 [[RET_RELOAD]]
 entry:
   %sum = add i32 %x, %y


### PR DESCRIPTION
The denotePHINode function was being executed even when
its corresponding pass was not enabled in the configuration
file.
This change moves the function to a more appropriate location
and ensures it is executed only when string obfuscation is
actually performed.