### PR TITLE
Add support for LLVM 21 / Xcode 26.4 toolchain

### DIFF
--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -19,13 +19,13 @@ jobs:
       - name: O-MVLL Build Plugins
         shell: bash
         run: |
-          curl -LO https://open-obfuscator.build38.io/static/omvll-v1.4.0-macos-deps.tar
-          mkdir -p /tmp/third-party-xcode16
-          tar xvf ./omvll-v1.4.0-macos-deps.tar --directory=/tmp/third-party-xcode16
+          curl -LO https://open-obfuscator.build38.io/static/omvll-v1.7.0-macos-deps.tar
+          mkdir -p /tmp/third-party-xcode26
+          tar xvf ./omvll-v1.7.0-macos-deps.tar --directory=/tmp/third-party-xcode26
           docker run --rm \
-            -v /tmp/third-party-xcode16/omvll-v1.4.0-macos-deps:/deps \
+            -v /tmp/third-party-xcode26/omvll-v1.7.0-macos-deps:/deps \
             -v $GITHUB_WORKSPACE:/o-mvll \
-            openobfuscator/omvll-build:latest bash /o-mvll/scripts/docker/xcode_16_compile.sh
+            openobfuscator/omvll-build:latest bash /o-mvll/scripts/docker/xcode_26_compile.sh
       - name: O-MVLL Sign Xcode Plugin
         uses: indygreg/apple-code-sign-action@v1.0
         with:

--- a/scripts/docker/dockerfiles/omvll.dockerfile
+++ b/scripts/docker/dockerfiles/omvll.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 LABEL maintainer="Romain Thomas <me@romainthomas.fr>"
 
 # This can be obtained following the instructions here: https://github.com/tpoechtrager/osxcross?tab=readme-ov-file#packaging-the-sdk
-COPY MacOSX15.4.sdk.tar.xz /
+COPY MacOSX26.4.sdk.tar.xz /
 
 RUN mkdir -p /usr/share/man/man1                                      && \
     apt-get update -y                                                 && \
@@ -15,9 +15,9 @@ RUN mkdir -p /usr/share/man/man1                                      && \
     software-properties-common gnupg                                     \
   && wget https://apt.llvm.org/llvm.sh                                   \
   && chmod u+x llvm.sh                                                   \
-  && ./llvm.sh 19 all                                                    \
-  && ln -s /usr/bin/clang-19 /usr/bin/clang                              \
-  && ln -s /usr/bin/clang++-19 /usr/bin/clang++                          \
+  && ./llvm.sh 21 all                                                    \
+  && ln -s /usr/bin/clang-21 /usr/bin/clang                              \
+  && ln -s /usr/bin/clang++-21 /usr/bin/clang++                          \
   && apt-get clean                                                       \
   && rm -rf /var/lib/apt/lists/*
 
@@ -30,12 +30,12 @@ RUN git config --global --add safe.directory /o-mvll
 # Copy in missing test dependencies
 RUN mkdir -p /test-deps/bin
 RUN ln -s /opt/venv/bin/lit /test-deps/bin/llvm-lit
-RUN cd /usr/lib/llvm-19/bin && cp llvm-config FileCheck count not /test-deps/bin/. && cd /
+RUN cd /usr/lib/llvm-21/bin && cp llvm-config FileCheck count not /test-deps/bin/. && cd /
 
 # OSXCross compilation
 RUN mkdir -p /osxcross && cd /osxcross && \
     git clone --depth 1 https://github.com/tpoechtrager/osxcross && \
-    cd osxcross && ln -s /MacOSX15.4.sdk.tar.xz tarballs/ && \
+    cd osxcross && ln -s /MacOSX26.4.sdk.tar.xz tarballs/ && \
     TARGET_DIR=/osxcross/install UNATTENDED=1 bash ./build.sh && \
     mv /osxcross/install/* /osxcross
 

--- a/scripts/docker/xcode_26_compile.sh
+++ b/scripts/docker/xcode_26_compile.sh
@@ -7,8 +7,8 @@
 set -ex
 
 cd /deps
-tar xzvf LLVM-19.1.4git-arm64-Darwin.tar.gz
-tar xzvf LLVM-19.1.4git-x86_64-Darwin.tar.gz
+tar xzvf LLVM-21.1.6-arm64-Darwin.tar.gz
+tar xzvf LLVM-21.1.6-x86_64-Darwin.tar.gz
 tar xzvf LLVM17-NDK26-Darwin.tar.gz
 tar xzvf Python-slim.tar.gz
 tar xzvf pybind11.tar.gz
@@ -20,11 +20,11 @@ cd /o-mvll/src
 mkdir -p build_xcode && cd build_xcode
 
 export OSXCROSS_TARGET_DIR=/osxcross
-export OSXCROSS_SDK=${OSXCROSS_TARGET_DIR}/SDK/MacOSX15.4.sdk
+export OSXCROSS_SDK=${OSXCROSS_TARGET_DIR}/SDK/MacOSX26.4.sdk
 export OMVLL_PYTHONPATH=/omvll/ci/distribution/Python-3.10.7/Lib
 
-export OSXCROSS_HOST="arm64-apple-darwin24.4"
-export OSXCROSS_TARGET="arm64-apple-darwin24.4"
+export OSXCROSS_HOST="arm64-apple-darwin25.4"
+export OSXCROSS_TARGET="arm64-apple-darwin25.4"
 
 cmake -GNinja -Bxcode-arm64 -S.. \
       -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
@@ -40,7 +40,7 @@ cmake -GNinja -Bxcode-arm64 -S.. \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
-      -DLLVM_DIR=/deps/LLVM-19.1.4git-arm64-Darwin/lib/cmake/llvm \
+      -DLLVM_DIR=/deps/LLVM-21.1.6-arm64-Darwin/lib/cmake/llvm \
       -DOMVLL_ABI=Apple
 ninja -C xcode-arm64
 
@@ -62,8 +62,8 @@ cmake -GNinja -Bndk-arm64 -S.. \
       -DOMVLL_ABI=Android
 ninja -C ndk-arm64
 
-export OSXCROSS_HOST="x86_64-apple-darwin24.4"
-export OSXCROSS_TARGET="x86_64-apple-darwin24.4"
+export OSXCROSS_HOST="x86_64-apple-darwin25.4"
+export OSXCROSS_TARGET="x86_64-apple-darwin25.4"
 
 cmake -GNinja -Bxcode-x86_64 -S.. \
       -DCMAKE_TOOLCHAIN_FILE=${OSXCROSS_TARGET_DIR}/toolchain.cmake \
@@ -79,7 +79,7 @@ cmake -GNinja -Bxcode-x86_64 -S.. \
       -DPython3_INCLUDE_DIR=/deps/include/python3.10 \
       -Dpybind11_DIR=/deps/share/cmake/pybind11 \
       -Dspdlog_DIR=/deps/lib/cmake/spdlog \
-      -DLLVM_DIR=/deps/LLVM-19.1.4-Darwin/lib/cmake/llvm \
+      -DLLVM_DIR=/deps/LLVM-21.1.6-x86_64-Darwin/lib/cmake/llvm \
       -DOMVLL_ABI=Apple
 ninja -C xcode-x86_64
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,9 +30,11 @@ set(OMVLL_ABI "${OMVLL_DEFAULT_ABI}" CACHE STRING
   "Compiler ABI to build OMVLL against. Supported options are \"Apple\" and \"Android\". Defaults to ${OMVLL_DEFAULT_ABI}.")
 
 if(OMVLL_ABI STREQUAL "Apple")
-  set(LLVM_REQUIRED_VERSION 19.1.4)
+  set(LLVM_REQUIRED_VERSION 21.1.6 CACHE STRING
+    "Required LLVM version for the Apple ABI (matches Xcode 26.4 / clang 21)")
 elseif(OMVLL_ABI STREQUAL "Android")
-  set(LLVM_REQUIRED_VERSION 17)
+  set(LLVM_REQUIRED_VERSION 17 CACHE STRING
+    "Required LLVM version for the Android NDK ABI")
 else()
   # TODO: switch Linux build to release NDK
   set(LLVM_REQUIRED_VERSION 17.0.2)
@@ -136,9 +138,16 @@ if(NOT APPLE)
 endif()
 
 if(APPLE)
+  # ld64 resolves every entry in -exported_symbols_list against the link unit;
+  # the ORC EH-frame helpers were renamed in LLVM 20 (Wrapper -> AllocAction).
+  if(LLVM_VERSION_MAJOR GREATER_EQUAL 20)
+    set(OMVLL_EXPORTS_LIST "${CMAKE_CURRENT_SOURCE_DIR}/exports.txt")
+  else()
+    set(OMVLL_EXPORTS_LIST "${CMAKE_CURRENT_SOURCE_DIR}/exports.legacy.txt")
+  endif()
   list(APPEND OMVLL_LINK_OPT
     -Wl,-flat_namespace
-    -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/exports.txt
+    -Wl,-exported_symbols_list,${OMVLL_EXPORTS_LIST}
   )
 endif()
 

--- a/src/core/jitter.cpp
+++ b/src/core/jitter.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
 #include "omvll/jitter.hpp"
@@ -64,7 +65,8 @@ void Jitter::initializeArchTarget() {
     else if (TT.isX86())
       initializeX86Assembler();
     else
-      fatalError(fmt::format("Unsupported arch type: {}", TT.getArch()));
+      fatalError(fmt::format("Unsupported arch type: {}",
+                             Triple::getArchTypeName(TT.getArch())));
     HasArchTargetInitialized = true;
   }
 }

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -22,6 +22,13 @@
 
 using namespace llvm;
 
+// LLVM 20 added a ThinOrFullLTOPhase parameter to the EP callback signatures.
+#if LLVM_VERSION_MAJOR >= 20
+#define OMVLL_EP_CALLBACK_LTO_ARG , ThinOrFullLTOPhase
+#else
+#define OMVLL_EP_CALLBACK_LTO_ARG
+#endif
+
 static llvm::once_flag InitializePluginFlag;
 
 using PassFactory = std::function<void(ModulePassManager &)>;
@@ -170,13 +177,15 @@ PassPluginLibraryInfo getOMVLLPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "OMVLL", "1.4.1", [](PassBuilder &PB) {
             try {
               PB.registerPipelineEarlySimplificationEPCallback(
-                  [](ModulePassManager &MPM, OptimizationLevel Opt) {
+                  [](ModulePassManager &MPM, OptimizationLevel
+                         OMVLL_EP_CALLBACK_LTO_ARG) {
                     MPM.addPass(omvll::LoggerBind());
                     addPassesForPhase(MPM, omvll::Phase::Early);
                     return true;
                   });
               PB.registerOptimizerLastEPCallback(
-                  [](ModulePassManager &MPM, OptimizationLevel Opt) {
+                  [](ModulePassManager &MPM, OptimizationLevel
+                         OMVLL_EP_CALLBACK_LTO_ARG) {
                     addPassesForPhase(MPM, omvll::Phase::Last);
                     return true;
                   });
@@ -185,6 +194,8 @@ PassPluginLibraryInfo getOMVLLPluginInfo() {
             }
           }};
 }
+
+#undef OMVLL_EP_CALLBACK_LTO_ARG
 
 __attribute__((visibility("default")))
 extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -263,7 +263,9 @@ std::string TypeIDStr(const Type &Ty) {
     case Type::TypeID::VoidTyID:           return "VoidTyID";
     case Type::TypeID::LabelTyID:          return "LabelTyID";
     case Type::TypeID::MetadataTyID:       return "MetadataTyID";
+#if LLVM_VERSION_MAJOR < 20
     case Type::TypeID::X86_MMXTyID:        return "X86_MMXTyID";
+#endif
     case Type::TypeID::X86_AMXTyID:        return "X86_AMXTyID";
     case Type::TypeID::TokenTyID:          return "TokenTyID";
     case Type::TypeID::IntegerTyID:        return "IntegerTyID";

--- a/src/exports.legacy.txt
+++ b/src/exports.legacy.txt
@@ -1,0 +1,3 @@
+_llvmGetPassPluginInfo
+_llvm_orc_registerEHFrameSectionWrapper
+_llvm_orc_deregisterEHFrameSectionWrapper

--- a/src/exports.txt
+++ b/src/exports.txt
@@ -1,3 +1,3 @@
 _llvmGetPassPluginInfo
-_llvm_orc_registerEHFrameSectionWrapper
-_llvm_orc_deregisterEHFrameSectionWrapper
+_llvm_orc_registerEHFrameSectionAllocAction
+_llvm_orc_deregisterEHFrameSectionAllocAction

--- a/src/include/omvll/utils.hpp
+++ b/src/include/omvll/utils.hpp
@@ -9,7 +9,9 @@
 #include <string>
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Triple.h"
@@ -20,7 +22,6 @@ class Instruction;
 class BasicBlock;
 class CallInst;
 class Function;
-class Module;
 class Type;
 class Value;
 class MDNode;
@@ -28,6 +29,14 @@ class MemoryBuffer;
 } // end namespace llvm
 
 namespace omvll {
+
+inline std::string getModuleTripleStr(const llvm::Module &M) {
+#if LLVM_VERSION_MAJOR >= 20
+  return M.getTargetTriple().str();
+#else
+  return M.getTargetTriple();
+#endif
+}
 
 std::string ToString(const llvm::Module &M);
 std::string ToString(const llvm::BasicBlock &BB);

--- a/src/passes/anti-hook/AntiHook.cpp
+++ b/src/passes/anti-hook/AntiHook.cpp
@@ -81,7 +81,7 @@ PreservedAnalyses AntiHook::run(Module &M, ModuleAnalysisManager &FAM) {
   bool Changed = false;
   PyConfig &Config = PyConfig::instance();
   SINFO("[{}] Executing on module {}", name(), M.getName());
-  JIT = std::make_unique<Jitter>(M.getTargetTriple());
+  JIT = std::make_unique<Jitter>(getModuleTripleStr(M));
 
   for (Function &F : M) {
     if (isFunctionGloballyExcluded(&F) ||

--- a/src/passes/break-cfg/BreakControlFlow.cpp
+++ b/src/passes/break-cfg/BreakControlFlow.cpp
@@ -255,7 +255,7 @@ PreservedAnalyses BreakControlFlow::run(Module &M, ModuleAnalysisManager &FAM) {
   if (ToVisit.empty())
     return PreservedAnalyses::all();
 
-  JIT = std::make_unique<Jitter>(M.getTargetTriple());
+  JIT = std::make_unique<Jitter>(getModuleTripleStr(M));
 
   unsigned int NumVisits = 0;
   for (Function *F : ToVisit)

--- a/src/passes/string-encoding/StringEncoding.cpp
+++ b/src/passes/string-encoding/StringEncoding.cpp
@@ -677,7 +677,11 @@ bool StringEncoding::processGlobal(Use &Op, GlobalVariable &G,
   FunctionType *FTy = FunctionType::get(Type::getVoidTy(Ctx), /* no args */ {},
                                         /* no var args */ false);
 
-#if LLVM_VERSION_MAJOR > 18
+#if LLVM_VERSION_MAJOR >= 20
+  const std::string GlobalID = GlobalValue::getGlobalIdentifier(
+      G.getName(), G.getLinkage(), M->getModuleIdentifier());
+  unsigned GlobalIDHashVal = xxh3_64bits(GlobalID);
+#elif LLVM_VERSION_MAJOR > 18
   unsigned GlobalIDHashVal = xxh3_64bits(G.getGlobalIdentifier());
 #else
   unsigned GlobalIDHashVal =


### PR DESCRIPTION
## Summary

Ports the Apple ABI build to LLVM 21.1.6, matching the toolchain shipped with Xcode 26.4 (Apple clang 21), while keeping the Android NDK build on LLVM 17.

Builds on #149 by @gast04 and incorporates the review feedback from @alexland7219:

* Every ABI-breaking adjustment is gated with `#if LLVM_VERSION_MAJOR >= 20` (or `< 20`) so the Android NDK build keeps compiling against LLVM 17.
* `LLVM_REQUIRED_VERSION` is set to `21.1.6` (instead of `21.1.8`) and is now CACHE-overridable for local development.
* The `registerOptimizerLastEPCallback` introduced by #151 (which #149 predates) also requires the new `ThinOrFullLTOPhase` argument; both EP callbacks share a single `OMVLL_EP_CALLBACK_LTO_ARG` macro.

## Upstream API breaks addressed

| LLVM 20+ change | Touched files |
|---|---|
| `PassBuilder` EP callbacks gain `ThinOrFullLTOPhase` | `src/core/plugin.cpp` |
| `Module::getTargetTriple()` returns `Triple` (was `std::string`) | `src/include/omvll/utils.hpp`, `src/passes/anti-hook/AntiHook.cpp`, `src/passes/break-cfg/BreakControlFlow.cpp` |
| `GlobalVariable::getGlobalIdentifier()` instance method removed | `src/passes/string-encoding/StringEncoding.cpp` |
| `Type::TypeID::X86_MMXTyID` removed with the MMX backend | `src/core/utils.cpp` |
| `fmt` v12 no longer formats `Triple::ArchType` implicitly | `src/core/jitter.cpp` |
| ORC EH-frame helpers renamed (`*Wrapper` -> `*AllocAction`) | `src/exports.txt`, `src/exports.legacy.txt`, `src/CMakeLists.txt` |

## Build infrastructure

* `MacOSX26.4.sdk` replaces `MacOSX15.4.sdk` in the OSXCross/Docker image.
* The apt LLVM toolchain in the build container is bumped to `clang-21`.
* `scripts/docker/xcode_16_compile.sh` is renamed to `xcode_26_compile.sh` and references `LLVM-21.1.6-{arm64,x86_64}-Darwin.tar.gz` and `MacOSX26.4.sdk`.
* The GitHub Actions workflow now fetches `omvll-v1.7.0-macos-deps.tar`.

The new dependency artifacts (`omvll-v1.7.0-macos-deps.tar`, `LLVM-21.1.6-*-Darwin.tar.gz`, `MacOSX26.4.sdk.tar.xz`) need to be produced and published by Build38 for CI to turn green.

## Test plan

Validated locally on macOS 26.4 (arm64) against a Homebrew LLVM 21.1.8 install:

- [x] `cmake -GNinja -DOMVLL_ABI=Apple -DLLVM_REQUIRED_VERSION=21.1.8 ...; ninja` builds `libOMVLL.dylib` cleanly.
- [x] The plugin loads into Apple clang 21 (Xcode 26.4) via `-fpass-plugin=`.
- [x] `flatten_cfg` + `obfuscate_arithmetic` on a `check_password` sample inflate its disassembly from ~10 to ~237 instructions; the obfuscated binary executes and produces the expected output.
- [ ] CI Docker/cross build (blocked on the deps tarball being published).

## Out of scope

LLVM 21 surfaces deprecation warnings for `Instruction::insertBefore`, `BasicBlock::getFirstNonPHI`, and `PointerType::getUnqual`. These predate this PR and a migration to the iterator-based APIs is better handled as a focused follow-up.