### PR TITLE
ConstantObfuscation: Force arithmetics to obfuscated constants

### DIFF
--- a/src/core/python/pyobf_opt.cpp
+++ b/src/core/python/pyobf_opt.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "omvll/passes/ObfuscationOpt.hpp"
+#include <pybind11/pytypes.h>
 
 #include "init.hpp"
 
@@ -126,9 +127,11 @@ py::module_ &py_init_obf_opt(py::module_ &m) {
     R"delim(
     Option for the :meth:`omvll.ObfuscationConfig.obfuscate_constants` protection.
 
-    This option defines lower limit from which constants must be obfuscated (e.g. ``OpaqueConstantsLowerLimit(100)``)
+    This option defines lower limit from which constants must be obfuscated (e.g. ``OpaqueConstantsLowerLimit(100)``).
+    An optional ``arith_rounds`` parameter controls how many rounds of arithmetic obfuscation
+    are applied to the generated opaque expressions (e.g. ``OpaqueConstantsLowerLimit(100, arith_rounds=2)``).
     )delim")
-    .def(py::init<uint64_t>(), "limit"_a);
+    .def(py::init<uint64_t, uint8_t>(), "limit"_a, "arith_rounds"_a = 0);
 
   py::class_<OpaqueConstantsBool>(m, "OpaqueConstantsBool",
     R"delim(
@@ -136,8 +139,10 @@ py::module_ &py_init_obf_opt(py::module_ &m) {
 
     This option defines whether or not the constants must be obfuscated. If the value is set to `False`,
     the constants are not protected otherwise, **all** the constants are protected.
+    An optional ``arith_rounds`` parameter controls how many rounds of arithmetic obfuscation
+    are applied to the generated opaque expressions (e.g. ``OpaqueConstantsBool(True, arith_rounds=2)``).
     )delim")
-    .def(py::init<bool>(), "value"_a);
+    .def(py::init<bool, uint8_t>(), "value"_a, "arith_rounds"_a = 0);
 
   py::class_<OpaqueConstantsSkip>(m, "OpaqueConstantsSkip",
     R"delim(
@@ -152,9 +157,22 @@ py::module_ &py_init_obf_opt(py::module_ &m) {
     Option for the :meth:`omvll.ObfuscationConfig.obfuscate_constants` protection.
 
     This option takes a list of constants that must be protected by the pass
-    (e.g. ``OpaqueConstantsSet([0x12234, 1, 2])``)
+    (e.g. ``OpaqueConstantsSet([0x12234, 1, 2])``).
+    An optional ``arith_rounds`` parameter controls how many rounds of arithmetic obfuscation
+    are applied to the generated opaque expressions (e.g. ``OpaqueConstantsSet([1, 2], arith_rounds=2)``).
     )delim")
-    .def(py::init<std::vector<uint64_t>>(), "constants"_a);
+    .def(py::init<std::vector<uint64_t>, uint8_t>(), "constants"_a, "arith_rounds"_a = 0);
+
+  py::class_<OpaqueConstantsExceptSet>(m, "OpaqueConstantsExceptSet",
+    R"delim(
+    Option for the :meth:`omvll.ObfuscationConfig.obfuscate_constants` protection.
+
+    This option takes a list of constants that cannot be protected by the pass
+    (e.g. ``OpaqueConstantsExceptSet([0x12234, 1, 2])``).
+    An optional ``arith_rounds`` parameter controls how many rounds of arithmetic obfuscation
+    are applied to the generated opaque expressions (e.g. ``OpaqueConstantsExceptSet([1, 2], arith_rounds=2)``).
+    )delim")
+    .def(py::init<std::vector<uint64_t>, uint8_t>(), "constants"_a, "arith_rounds"_a = 0);
 
   // Indirect Branch
   py::class_<IndirectBranchOpt>(m, "IndirectBranchOpt",

--- a/src/core/python/pyobf_opt.cpp
+++ b/src/core/python/pyobf_opt.cpp
@@ -163,14 +163,14 @@ py::module_ &py_init_obf_opt(py::module_ &m) {
     )delim")
     .def(py::init<std::vector<uint64_t>, uint8_t>(), "constants"_a, "arith_rounds"_a = 0);
 
-  py::class_<OpaqueConstantsExceptSet>(m, "OpaqueConstantsExceptSet",
+  py::class_<OpaqueConstantsExcludeSet>(m, "OpaqueConstantsExcludeSet",
     R"delim(
     Option for the :meth:`omvll.ObfuscationConfig.obfuscate_constants` protection.
 
     This option takes a list of constants that cannot be protected by the pass
-    (e.g. ``OpaqueConstantsExceptSet([0x12234, 1, 2])``).
+    (e.g. ``OpaqueConstantsExcludeSet([0x12234, 1, 2])``).
     An optional ``arith_rounds`` parameter controls how many rounds of arithmetic obfuscation
-    are applied to the generated opaque expressions (e.g. ``OpaqueConstantsExceptSet([1, 2], arith_rounds=2)``).
+    are applied to the generated opaque expressions (e.g. ``OpaqueConstantsExcludeSet([1, 2], arith_rounds=2)``).
     )delim")
     .def(py::init<std::vector<uint64_t>, uint8_t>(), "constants"_a, "arith_rounds"_a = 0);
 

--- a/src/include/omvll/passes/arithmetic/Arithmetic.hpp
+++ b/src/include/omvll/passes/arithmetic/Arithmetic.hpp
@@ -5,6 +5,9 @@
 // details.
 //
 
+#include <cstddef>
+#include <optional>
+
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/ADT/DenseMap.h"
@@ -25,7 +28,10 @@ namespace omvll {
 struct Arithmetic : llvm::PassInfoMixin<Arithmetic> {
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &FAM);
-  bool runOnBasicBlock(llvm::BasicBlock &BB);
+  bool runOnBasicBlock(llvm::BasicBlock &BB,
+                       std::optional<size_t> Rounds = std::nullopt);
+  bool runOnFunction(llvm::Function &F,
+                     std::optional<size_t> Rounds = std::nullopt);
 
   llvm::Function *injectFunWrapper(llvm::Module &M, llvm::BinaryOperator &Op,
                                    llvm::Value &Lhs, llvm::Value &Rhs);

--- a/src/include/omvll/passes/opaque-constants/OpaqueConstants.hpp
+++ b/src/include/omvll/passes/opaque-constants/OpaqueConstants.hpp
@@ -8,6 +8,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/ADT/DenseMap.h"
 
+#include "omvll/passes/arithmetic/Arithmetic.hpp"
 #include "omvll/passes/opaque-constants/OpaqueConstantsOpt.hpp"
 
 // Forward declarations
@@ -47,6 +48,7 @@ struct OpaqueConstants : llvm::PassInfoMixin<OpaqueConstants> {
                             const llvm::ConstantInt &Val);
 
 private:
+  Arithmetic Arith;
   llvm::DenseMap<llvm::Function *, OpaqueContext> OpaqueCtx;
   llvm::DenseMap<llvm::Function *, OpaqueConstantsOpt> Opts;
 };

--- a/src/include/omvll/passes/opaque-constants/OpaqueConstantsOpt.hpp
+++ b/src/include/omvll/passes/opaque-constants/OpaqueConstantsOpt.hpp
@@ -16,32 +16,49 @@ namespace omvll {
 struct OpaqueConstantsSkip {};
 
 struct OpaqueConstantsBool  {
-  OpaqueConstantsBool(bool Value) : Value(Value) {}
+  OpaqueConstantsBool(bool Value, uint8_t ArithRounds = 0)
+      : Value(Value), ArithRounds(ArithRounds) {}
   operator bool() const { return Value; }
   bool Value = false;
+  uint8_t ArithRounds = 0;
 };
 
 struct OpaqueConstantsLowerLimit {
-  OpaqueConstantsLowerLimit(uint64_t Value) : Value(Value) {}
+  OpaqueConstantsLowerLimit(uint64_t Value, uint8_t ArithRounds = 0)
+      : Value(Value), ArithRounds(ArithRounds) {}
   operator bool() const { return Value > 0; }
   uint64_t Value = 0;
+  uint8_t ArithRounds = 0;
 };
 
 struct OpaqueConstantsSet {
-  OpaqueConstantsSet(std::vector<uint64_t> Value)
-      : Values(Value.begin(), Value.end()) {}
+  OpaqueConstantsSet(std::vector<uint64_t> Value, uint8_t ArithRounds = 0)
+      : Values(Value.begin(), Value.end()), ArithRounds(ArithRounds) {}
 
   inline bool contains(uint64_t Value) const { return Values.contains(Value); }
   inline bool empty() { return Values.empty(); };
   inline operator bool() const { return !Values.empty(); }
   llvm::DenseSet<uint64_t> Values;
+  uint8_t ArithRounds = 0;
+};
+
+struct OpaqueConstantsExceptSet {
+  OpaqueConstantsExceptSet(std::vector<uint64_t> Value, uint8_t ArithRounds = 0)
+      : Values(Value.begin(), Value.end()), ArithRounds(ArithRounds) {}
+
+  inline bool contains(uint64_t Value) const { return Values.contains(Value); }
+  inline bool empty() { return Values.empty(); };
+  inline operator bool() const { return !Values.empty(); }
+  llvm::DenseSet<uint64_t> Values;
+  uint8_t ArithRounds = 0;
 };
 
 using OpaqueConstantsOpt = std::variant<
   OpaqueConstantsSkip,
   OpaqueConstantsBool,
   OpaqueConstantsLowerLimit,
-  OpaqueConstantsSet
+  OpaqueConstantsSet,
+  OpaqueConstantsExceptSet
 >;
 
 } // end namespace omvll

--- a/src/include/omvll/passes/opaque-constants/OpaqueConstantsOpt.hpp
+++ b/src/include/omvll/passes/opaque-constants/OpaqueConstantsOpt.hpp
@@ -42,8 +42,8 @@ struct OpaqueConstantsSet {
   uint8_t ArithRounds = 0;
 };
 
-struct OpaqueConstantsExceptSet {
-  OpaqueConstantsExceptSet(std::vector<uint64_t> Value, uint8_t ArithRounds = 0)
+struct OpaqueConstantsExcludeSet {
+  OpaqueConstantsExcludeSet(std::vector<uint64_t> Value, uint8_t ArithRounds = 0)
       : Values(Value.begin(), Value.end()), ArithRounds(ArithRounds) {}
 
   inline bool contains(uint64_t Value) const { return Values.contains(Value); }
@@ -58,7 +58,7 @@ using OpaqueConstantsOpt = std::variant<
   OpaqueConstantsBool,
   OpaqueConstantsLowerLimit,
   OpaqueConstantsSet,
-  OpaqueConstantsExceptSet
+  OpaqueConstantsExcludeSet
 >;
 
 } // end namespace omvll

--- a/src/passes/arithmetic/Arithmetic.cpp
+++ b/src/passes/arithmetic/Arithmetic.cpp
@@ -219,39 +219,41 @@ Function *Arithmetic::injectFunWrapper(Module &M, BinaryOperator &Op,
   return F;
 }
 
-bool Arithmetic::runOnBasicBlock(BasicBlock &BB) {
+bool Arithmetic::runOnBasicBlock(BasicBlock &BB,
+                                 std::optional<size_t> ExplicitRounds) {
   size_t Counter = 0;
 
   SmallVector<Instruction *> ToErase;
   MapVector<Function *, size_t> ToObfuscate;
-  for (Instruction &I : BB) {
-    // First, check if there is O-MVLL metadata associated with the current
-    // instruction. If it is the case, access the number of iterations.
-    size_t Rounds = 0;
-    if (auto MO = getObf(I, MetaObfTy::OpaqueOp)) {
-      if (auto *Val = MO->get<uint64_t>()) {
-        Rounds = *Val;
 
-        if (auto It = Opts.find(BB.getParent()); It != Opts.end()) {
-          SINFO("[{}][{}] Metadata ({}) overrides rounds ({}) for {}", name(),
-                BB.getParent()->getName(), Rounds, It->second.Iterations,
-                I.getOpcodeName());
+  for (Instruction &I : BB) {
+    size_t Rounds = 0;
+
+    if (ExplicitRounds.has_value()) {
+      Rounds = *ExplicitRounds;
+    } else {
+      // Check for per-instruction O-MVLL metadata first, then fall back to the
+      // function-level opt.
+      if (auto MO = getObf(I, MetaObfTy::OpaqueOp)) {
+        if (auto *Val = MO->get<uint64_t>()) {
+          Rounds = *Val;
+
+          if (auto It = Opts.find(BB.getParent()); It != Opts.end()) {
+            SINFO("[{}][{}] Metadata ({}) overrides rounds ({}) for {}", name(),
+                  BB.getParent()->getName(), Rounds, It->second.Iterations,
+                  I.getOpcodeName());
+          }
         }
+      } else if (auto It = Opts.find(BB.getParent()); It != Opts.end()) {
+        Rounds = It->second.Iterations;
       }
-    } else if (auto It = Opts.find(BB.getParent()); It != Opts.end()) {
-      Rounds = It->second.Iterations;
     }
 
-    // No need to continue if there is a 0-round.
     if (Rounds == 0)
       continue;
 
-    // Now check that we are in a BinOp instruction.
     auto *BinOp = dyn_cast<BinaryOperator>(&I);
-    if (!BinOp)
-      continue;
-
-    if (!isSupported(*BinOp))
+    if (!BinOp || !isSupported(*BinOp))
       continue;
 
     Value *Lhs = BinOp->getOperand(0);
@@ -277,9 +279,9 @@ bool Arithmetic::runOnBasicBlock(BasicBlock &BB) {
   ArithmeticVisitor Visitor(Builder);
 
   for (const auto &[F, Round] : ToObfuscate) {
-    for (BasicBlock &BB : *F) {
+    for (BasicBlock &FBB : *F) {
       for (size_t Idx = 0; Idx < Round; ++Idx) {
-        for (Instruction &I : BB) {
+        for (Instruction &I : FBB) {
           if (getObf(I, MetaObfTy::OpaqueCst))
             continue;
 
@@ -290,7 +292,7 @@ bool Arithmetic::runOnBasicBlock(BasicBlock &BB) {
             continue;
 
           SDEBUG("[{}][{}] Replacing {} with {}", name(), F->getName(),
-                I.getOpcodeName(), Result->getName());
+                 I.getOpcodeName(), Result->getName());
 
           BasicBlock *InstParent = I.getParent();
           BasicBlock::iterator InsertPos = I.getIterator();
@@ -305,7 +307,14 @@ bool Arithmetic::runOnBasicBlock(BasicBlock &BB) {
     }
   }
 
-  bool Changed = Counter > 0;
+  return Counter > 0;
+}
+
+bool Arithmetic::runOnFunction(Function &F,
+                                 std::optional<size_t> ExplicitRounds){
+  bool Changed = false;
+  for (BasicBlock &BB : F)
+    Changed |= runOnBasicBlock(BB, ExplicitRounds);
   return Changed;
 }
 
@@ -339,8 +348,7 @@ PreservedAnalyses Arithmetic::run(Module &M, ModuleAnalysisManager &FAM) {
     SINFO("[{}] Visiting function {}", name(), F->getName());
     Opts.insert({F, std::move(Opt)});
 
-    for (BasicBlock &BB : *F)
-      Changed |= runOnBasicBlock(BB);
+    Changed |= runOnFunction(*F);
   }
 
   SINFO("[{}] Changes {} applied on module {}", name(), Changed ? "" : "not",

--- a/src/passes/opaque-constants/OpaqueConstants.cpp
+++ b/src/passes/opaque-constants/OpaqueConstants.cpp
@@ -225,6 +225,7 @@ PreservedAnalyses OpaqueConstants::run(Module &M, ModuleAnalysisManager &FAM) {
   SINFO("[{}] Executing on module {}", name(), M.getName());
 
   for (Function &F : M) {
+    bool ChangedFunction = false;
     if (isFunctionGloballyExcluded(&F) || F.isDeclaration() ||
         F.isIntrinsic() || F.getName().starts_with("__omvll"))
       continue;
@@ -242,10 +243,11 @@ PreservedAnalyses OpaqueConstants::run(Module &M, ModuleAnalysisManager &FAM) {
       // Don't try opaque constants when potentially handling infinite loops.
       if (is_contained(successors(&BB), &BB))
         continue;
-      Changed |= runOnBasicBlock(BB, Inserted);
+      ChangedFunction |= runOnBasicBlock(BB, Inserted);
     }
+    Changed |= ChangedFunction;
 
-    if (Changed && Inserted) {
+    if (ChangedFunction && Inserted) {
       size_t ArithRounds = std::visit(overloaded{
           [](OpaqueConstantsSkip &)          -> size_t { return 0; },
           [](OpaqueConstantsBool &V)         -> size_t { return V.ArithRounds; },

--- a/src/passes/opaque-constants/OpaqueConstants.cpp
+++ b/src/passes/opaque-constants/OpaqueConstants.cpp
@@ -70,7 +70,7 @@ bool OpaqueConstants::process(Instruction &I, Use &Op, ConstantInt &CI,
                               return true;
                             return !V.empty() && V.contains(LV);
                           },
-                          [&](OpaqueConstantsExceptSet &V) {
+                          [&](OpaqueConstantsExcludeSet &V) {
                             if (CI.isZero())
                               return !V.contains(0);
                             if (CI.isOne())
@@ -253,7 +253,7 @@ PreservedAnalyses OpaqueConstants::run(Module &M, ModuleAnalysisManager &FAM) {
           [](OpaqueConstantsBool &V)         -> size_t { return V.ArithRounds; },
           [](OpaqueConstantsLowerLimit &V)   -> size_t { return V.ArithRounds; },
           [](OpaqueConstantsSet &V)          -> size_t { return V.ArithRounds; },
-          [](OpaqueConstantsExceptSet &V)    -> size_t { return V.ArithRounds; },
+          [](OpaqueConstantsExcludeSet &V)    -> size_t { return V.ArithRounds; },
       }, *Inserted);
       if (ArithRounds > 0)
         Arith.runOnFunction(F, ArithRounds);

--- a/src/passes/opaque-constants/OpaqueConstants.cpp
+++ b/src/passes/opaque-constants/OpaqueConstants.cpp
@@ -70,6 +70,18 @@ bool OpaqueConstants::process(Instruction &I, Use &Op, ConstantInt &CI,
                               return true;
                             return !V.empty() && V.contains(LV);
                           },
+                          [&](OpaqueConstantsExceptSet &V) {
+                            if (CI.isZero())
+                              return !V.contains(0);
+                            if (CI.isOne())
+                              return !V.contains(1);
+                            static constexpr uint64_t Magic =
+                                0x4208D8DF2C6415BC;
+                            const uint64_t LV = CI.getLimitedValue(Magic);
+                            if (LV == Magic)
+                              return true;
+                            return V.empty() || !V.contains(LV);
+                          },
                       },
                       *Opt);
   };
@@ -82,11 +94,20 @@ bool OpaqueConstants::process(Instruction &I, Use &Op, ConstantInt &CI,
   if (CI.isZero()) {
     // Special processing for 0 values.
     NewVal = getOpaqueZero(I, *Ctx, CI.getType());
+    #ifdef OMVLL_DEBUG
+      SDEBUG("[{}][{}] Opaquized", name(), CI.getLimitedValue());
+    #endif
   } else if (CI.isOne()) {
     // Special processing for 1 values.
     NewVal = getOpaqueOne(I, *Ctx, CI.getType());
+    #ifdef OMVLL_DEBUG
+      SDEBUG("[{}][{}] Opaquized", name(), CI.getLimitedValue());
+    #endif
   } else {
     NewVal = getOpaqueCst(I, *Ctx, CI);
+    #ifdef OMVLL_DEBUG
+      SDEBUG("[{}][{}] Opaquized", name(), CI.getLimitedValue());
+    #endif
   }
 
   if (!NewVal) {
@@ -223,6 +244,19 @@ PreservedAnalyses OpaqueConstants::run(Module &M, ModuleAnalysisManager &FAM) {
         continue;
       Changed |= runOnBasicBlock(BB, Inserted);
     }
+
+    if (Changed && Inserted) {
+      size_t ArithRounds = std::visit(overloaded{
+          [](OpaqueConstantsSkip &)          -> size_t { return 0; },
+          [](OpaqueConstantsBool &V)         -> size_t { return V.ArithRounds; },
+          [](OpaqueConstantsLowerLimit &V)   -> size_t { return V.ArithRounds; },
+          [](OpaqueConstantsSet &V)          -> size_t { return V.ArithRounds; },
+          [](OpaqueConstantsExceptSet &V)    -> size_t { return V.ArithRounds; },
+      }, *Inserted);
+      if (ArithRounds > 0)
+        Arith.runOnFunction(F, ArithRounds);
+    }
+
   }
 
   SINFO("[{}] Changes {} applied on module {}", name(), Changed ? "" : "not",


### PR DESCRIPTION
After applying Constant Obfuscation, add the possibility of applying rounds of arithmetics
Add the possibility to exclude a set of constants in config