### PR TITLE
Fix zstd symbol resolution in GitHub Actions for Xcode

### DIFF
--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -40,6 +40,13 @@ jobs:
           output_path: ${{ github.workspace }}/src/build_xcode/omvll-ndk.dylib
           p12_file: ${{ github.workspace }}/scripts/certificates/SigningCertificate.p12
           p12_password: ${{ secrets.certificate_password }}
+      - name: Upload plugins
+        uses: actions/upload-artifact@v4
+        with:
+          name: omvll-plugins
+          path: |
+            ${{ github.workspace }}/src/build_xcode/omvll-xcode.dylib
+            ${{ github.workspace }}/src/build_xcode/omvll-ndk.dylib
       - name: Generate distribution folder
         shell: bash
         run: |

--- a/scripts/docker/xcode_26_compile.sh
+++ b/scripts/docker/xcode_26_compile.sh
@@ -14,17 +14,39 @@ tar xzvf Python-slim.tar.gz
 tar xzvf pybind11.tar.gz
 tar xzvf spdlog-1.10.0-Darwin.tar.gz
 
-sed -i 's/;zstd::libzstd_shared//g; s/zstd::libzstd_shared;//g' /deps/LLVM-21.1.6-arm64-Darwin/lib/cmake/llvm/LLVMExports.cmake
-sed -i 's/;zstd::libzstd_shared//g; s/zstd::libzstd_shared;//g' /deps/LLVM-21.1.6-x86_64-Darwin/lib/cmake/llvm/LLVMExports.cmake
-
-cd /o-mvll/src
-
-# TODO: rename, build_macos?
-mkdir -p build_xcode && cd build_xcode
-
 export OSXCROSS_TARGET_DIR=/osxcross
 export OSXCROSS_SDK=${OSXCROSS_TARGET_DIR}/SDK/MacOSX26.4.sdk
 export OMVLL_PYTHONPATH=/omvll/ci/distribution/Python-3.10.7/Lib
+
+# Cross-compile a static zstd for each macOS architecture.
+ZSTD_VERSION="1.5.6"
+cd /tmp
+curl -fsSL "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz" -o zstd.tar.gz
+tar xzf zstd.tar.gz
+
+cp -r /tmp/zstd-${ZSTD_VERSION} /tmp/zstd_arm64
+make -C /tmp/zstd_arm64/lib libzstd.a \
+  CC="${OSXCROSS_TARGET_DIR}/bin/arm64-apple-darwin25.4-clang" \
+  AR="${OSXCROSS_TARGET_DIR}/bin/arm64-apple-darwin25.4-ar" \
+  RANLIB="${OSXCROSS_TARGET_DIR}/bin/arm64-apple-darwin25.4-ranlib" \
+  CFLAGS="-arch arm64 -mmacosx-version-min=15.4 -isysroot ${OSXCROSS_SDK}"
+cp /tmp/zstd_arm64/lib/libzstd.a /deps/libzstd_arm64.a
+
+cp -r /tmp/zstd-${ZSTD_VERSION} /tmp/zstd_x86_64
+make -C /tmp/zstd_x86_64/lib libzstd.a \
+  CC="${OSXCROSS_TARGET_DIR}/bin/x86_64-apple-darwin25.4-clang" \
+  AR="${OSXCROSS_TARGET_DIR}/bin/x86_64-apple-darwin25.4-ar" \
+  RANLIB="${OSXCROSS_TARGET_DIR}/bin/x86_64-apple-darwin25.4-ranlib" \
+  CFLAGS="-arch x86_64 -mmacosx-version-min=15.4 -isysroot ${OSXCROSS_SDK}"
+cp /tmp/zstd_x86_64/lib/libzstd.a /deps/libzstd_x86_64.a
+
+# Point LLVM's cmake exports at the static libs
+sed -i 's/zstd::libzstd_shared/\/deps\/libzstd_arm64.a/g' /deps/LLVM-21.1.6-arm64-Darwin/lib/cmake/llvm/LLVMExports.cmake
+sed -i 's/zstd::libzstd_shared/\/deps\/libzstd_x86_64.a/g' /deps/LLVM-21.1.6-x86_64-Darwin/lib/cmake/llvm/LLVMExports.cmake
+
+cd /o-mvll/src
+
+mkdir -p build_xcode && cd build_xcode
 
 export OSXCROSS_HOST="arm64-apple-darwin25.4"
 export OSXCROSS_TARGET="arm64-apple-darwin25.4"


### PR DESCRIPTION
In `xcode_26_compile.sh`, cross-compile a static `libzstd.a` for each macOS architecture using the osxcross clang already present in the Docker image. Replace `zstd::libzstd_shared` in `LLVMExports.cmake` with the path to the corresponding static lib, so zstd symbols are fully resolved at build time.

Added an `upload-artifact` step in `xcode.yml` so the signed dylibs are available as a downloadable artifact (`omvll-plugins`) on every workflow run.