### PR TITLE
Update omvll-deps-ndk-r29d tarball

### DIFF
--- a/.github/workflows/ndk.yml
+++ b/.github/workflows/ndk.yml
@@ -19,7 +19,7 @@ jobs:
       - name: O-MVLL Android NDK r29d
         shell: bash
         run: |
-          curl -LO https://open-obfuscator.dev.build38.io/static/omvll-deps-ndk-r29d.tar
+          curl -LO https://open-obfuscator.build38.io/static/omvll-deps-ndk-r29d.tar
           mkdir -p /tmp/third-party-ndk29
           tar xvf ./omvll-deps-ndk-r29d.tar --directory=/tmp/third-party-ndk29
           curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz

--- a/.github/workflows/ndk.yml
+++ b/.github/workflows/ndk.yml
@@ -19,7 +19,7 @@ jobs:
       - name: O-MVLL Android NDK r29d
         shell: bash
         run: |
-          curl -LO https://open-obfuscator.build38.io/static/omvll-deps-ndk-r29d.tar
+          curl -LO https://open-obfuscator.dev.build38.io/static/omvll-deps-ndk-r29d.tar
           mkdir -p /tmp/third-party-ndk29
           tar xvf ./omvll-deps-ndk-r29d.tar --directory=/tmp/third-party-ndk29
           curl -LO https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz
@@ -29,6 +29,12 @@ jobs:
             -v ${{ github.workspace }}/dist/Python-3.10.7:/Python-3.10.7 \
             -v $GITHUB_WORKSPACE:/o-mvll \
             openobfuscator/omvll-build:latest bash /o-mvll/scripts/docker/ndk_r29_compile.sh
+      - name: Upload plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: omvll-plugin
+          path: |
+            ${{ github.workspace }}/dist/omvll-ndk.so
       - name: Generate deployment tar
         uses: a7ul/tar-action@v1.1.3
         id: compress

--- a/scripts/deps/ndk/compile_llvm_r29d.sh
+++ b/scripts/deps/ndk/compile_llvm_r29d.sh
@@ -4,30 +4,37 @@
 # This file is distributed under the Apache License v2.0. See LICENSE for details.
 #
 
-# This script is used to compile the Android NDK r26d LLVM toolchain
+# This script is used to compile the Android NDK r29d LLVM toolchain
 
 set -e
 
 host=$(uname)
 
-NDK_VERSION=26.3.11579264
+NDK_VERSION=29.0.14206865
 
 if [ "$host" == "Darwin" ]; then
     ndk_platform="darwin-x86_64"
-    manifest="manifest_11349228.xml"
+    manifest="manifest_13989888.xml"
 else
     ndk_platform="linux-x86_64"
-    manifest="manifest_11349228.xml"
+    manifest="manifest_13989888.xml"
 fi
 
-mkdir android-llvm-toolchain-r26d-tmp && cd android-llvm-toolchain-r26d-tmp
+mkdir android-llvm-toolchain-r29d-tmp && cd android-llvm-toolchain-r29d-tmp
 repo init -u https://android.googlesource.com/platform/manifest -b llvm-toolchain
 
-cp $ANDROID_HOME/ndk/$NDK_VERSION/toolchains/llvm/prebuilt/$ndk_platform/${manifest} .repo/manifests/
+# Due to AOSP changes, the toolchain builds are not visible externally. 
+# The development branch of the toolchain is mirrored, but the release branches are not.
+# 
+# Hence we use a modified manifest_13989888.xml that uses the public mirrors.
+# 
+# [ERROR] cp $ANDROID_HOME/ndk/$NDK_VERSION/toolchains/llvm/prebuilt/$ndk_platform/${manifest} .repo/manifests/
+wget https://open-obfuscator.dev.build38.io/static/manifest_13989888.xml -P .repo/manifests/
+
 repo init -m ${manifest}
 repo sync -c
 
-python3 toolchain/llvm_android/build.py --skip-tests
+python3 toolchain/llvm_android/build.py --no-build windows --skip-tests
 
 export NDK_STAGE1=$(pwd)/out/stage1-install
 export NDK_STAGE2=$(pwd)/out/stage2-install
@@ -35,7 +42,7 @@ export NDK_STAGE2=$(pwd)/out/stage2-install
 zero_out() {
     local BIN_DIR="$1"
 
-    local KEEP_BINARIES=("clang-17" "clang" "clang++" "clang-cpp" "clang-cl" "clang-extdef-mapping" "clang-format"
+    local KEEP_BINARIES=("clang-21" "clang" "clang++" "clang-cpp" "clang-cl" "clang-extdef-mapping" "clang-format"
                          "clang-nvlink-wrapper" "clang-offload-bundler" "clang-offload-wrapper"
                          "git-clang-format" "hmaptool" "llvm-config" "llvm-link" "llvm-lit"
                          "llvm-tblgen" "FileCheck" "count" "not"
@@ -57,7 +64,7 @@ zero_out $NDK_STAGE1/bin
 zero_out $NDK_STAGE2/bin
 
 # Generate final package
-cd .. && mkdir -p android-llvm-toolchain-r26d/out && cd android-llvm-toolchain-r26d/out
+cd .. && mkdir -p android-llvm-toolchain-r29d/out && cd android-llvm-toolchain-r29d/out
 cp -r ${NDK_STAGE1} .
 cp -r ${NDK_STAGE2} .
 mv ./stage2-install stage2
@@ -65,10 +72,10 @@ mv ./stage2-install stage2
 tar czf stage1-install.tar.gz stage1-install && rm -rf stage1-install
 tar czf stage2.tar.gz stage2 && rm -rf stage2
 cd .. && tar czf out.tar.gz out && rm -rf out
-cd .. && tar czf android-llvm-toolchain-r26d.tar.gz android-llvm-toolchain-r26d
+cd .. && tar czf android-llvm-toolchain-r29d.tar.gz android-llvm-toolchain-r29d
 
 # Clean up
-rm -rf android-llvm-toolchain-r26d
+rm -rf android-llvm-toolchain-r29d
 
 # Move to the final folder
-mv android-llvm-toolchain-r26d.tar.gz ./omvll-deps/
+mv android-llvm-toolchain-r29d.tar.gz ./omvll-deps/

--- a/scripts/docker/ndk_r29_compile.sh
+++ b/scripts/docker/ndk_r29_compile.sh
@@ -38,7 +38,8 @@ cmake -GNinja .. \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_COMPILER=${NDK_STAGE1}/bin/clang++ \
       -DCMAKE_C_COMPILER=${NDK_STAGE1}/bin/clang \
-      -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++ -std=c++17" \
+      -DCMAKE_SHARED_LINKER_FLAGS="-static-libstdc++ -Wl,-Bstatic -lc++ -lc++abi -Wl,-Bdynamic" \
       -DPython3_ROOT_DIR=/data/Python-slim \
       -DPython3_LIBRARY=/data/Python-slim/lib/libpython3.10.a \
       -DPython3_INCLUDE_DIR=/data/Python-slim/include/python3.10 \

--- a/scripts/docker/ndk_r29_compile.sh
+++ b/scripts/docker/ndk_r29_compile.sh
@@ -17,6 +17,10 @@ tar xzvf Python-slim.tar.gz
 tar xzvf pybind11.tar.gz
 tar xzvf spdlog-1.10.0-Linux.tar.gz
 
+tar xzvf android-llvm-toolchain-r29d/out.tar.gz -C android-llvm-toolchain-r29d
+tar xzvf android-llvm-toolchain-r29d/out/stage1-install.tar.gz -C android-llvm-toolchain-r29d/out
+tar xzvf android-llvm-toolchain-r29d/out/stage2.tar.gz -C android-llvm-toolchain-r29d/out
+
 # Android NDK is bootstrapped in a so-called 2-stage process. To avoid ABI incompatibilities,
 # we build our plugin with the same toolchain used to build the NDK itself (stage-1). Then,
 # we link the plugin against stage-2 build artifacts.
@@ -34,7 +38,7 @@ cmake -GNinja .. \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_COMPILER=${NDK_STAGE1}/bin/clang++ \
       -DCMAKE_C_COMPILER=${NDK_STAGE1}/bin/clang \
-      -DCMAKE_CXX_FLAGS="-stdlib=libstdc++ -std=c++17" \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
       -DPython3_ROOT_DIR=/data/Python-slim \
       -DPython3_LIBRARY=/data/Python-slim/lib/libpython3.10.a \
       -DPython3_INCLUDE_DIR=/data/Python-slim/include/python3.10 \

--- a/src/test/passes/arithmetic/default-config-x86_64-linux-android.c
+++ b/src/test/passes/arithmetic/default-config-x86_64-linux-android.c
@@ -71,25 +71,31 @@
 // NEWSEED-NEXT   	cmpl	%edx, %eax
 // NEWSEED-NEXT   	jb	.LBB0_2
 
-
 // CHECKV2-LABEL: memcpy_xor:
 // CHECKV2:     .LBB0_2:
-// CHECKV2-NEXT: 	movl	%eax, %ecx
-// CHECKV2-NEXT: 	movzbl	(%rsi,%rcx), %r8d
-// CHECKV2-NEXT: 	leal	(%r8,%r8), %r9d
-// CHECKV2-NEXT: 	andb	$70, %r9b
-// CHECKV2-NEXT: 	subb	%r9b, %r8b
-// CHECKV2-NEXT: 	addb	$35, %r8b
-// CHECKV2-NEXT: 	movb	%r8b, (%rdi,%rcx)
-// CHECKV2-NEXT: 	movl	%eax, %ecx
-// CHECKV2-NEXT: 	notl	%ecx
-// CHECKV2-NEXT: 	orl	$-2, %ecx
-// CHECKV2-NEXT: 	addl	%eax, %ecx
-// CHECKV2-NEXT: 	andl	$1, %eax
-// CHECKV2-NEXT: 	addl	%ecx, %eax
-// CHECKV2-NEXT: 	addl	$2, %eax
-// CHECKV2-NEXT: 	cmpl	%edx, %eax
-// CHECKV2-NEXT: 	jb	.LBB0_2
+// CHECKV2-NEXT:    movl	%eax, %ecx
+// CHECKV2-NEXT:    movsbl	(%rsi,%rcx), %r8d
+// CHECKV2-NEXT:    movl	%r8d, %r9d
+// CHECKV2-NEXT:    notl	%r9d
+// CHECKV2-NEXT:    orl	$-36, %r9d
+// CHECKV2-NEXT:    addl	%r8d, %r9d
+// CHECKV2-NEXT:    addl	$36, %r9d
+// CHECKV2-NEXT:    andl	$35, %r8d
+// CHECKV2-NEXT:    negl	%r8d
+// CHECKV2-NEXT:    movl	%r9d, %r10d
+// CHECKV2-NEXT:    xorl	%r8d, %r10d
+// CHECKV2-NEXT:    andl	%r9d, %r8d
+// CHECKV2-NEXT:    leal	(%r10,%r8,2), %r8d
+// CHECKV2-NEXT:    movb	%r8b, (%rdi,%rcx)
+// CHECKV2-NEXT:    movl	%eax, %ecx
+// CHECKV2-NEXT:    notl	%ecx
+// CHECKV2-NEXT:    orl	$1, %ecx
+// CHECKV2-NEXT:    addl	%eax, %ecx
+// CHECKV2-NEXT:    orl	$1, %eax
+// CHECKV2-NEXT:    addl	%ecx, %eax
+// CHECKV2-NEXT:    incl	%eax
+// CHECKV2-NEXT:    cmpl	%edx, %eax
+// CHECKV2-NEXT:    jb	.LBB0_2
 
 void memcpy_xor(char *dst, const char *src, unsigned len) {
   for (unsigned i = 0; i < len; i += 1) {

--- a/src/test/passes/cfg-flattening/basic-aarch64-android.c
+++ b/src/test/passes/cfg-flattening/basic-aarch64-android.c
@@ -10,25 +10,24 @@
 // Check for jump table targets setup at the beginning of the function.
 
 // FLAT-ANDROID-LABEL:    check_password:
-// FLAT-ANDROID:	mov	w16, #42
-// FLAT-ANDROID-NEXT:	movk	w17, #41630, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w2, #36449, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w3, #59726, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w4, #30851, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w5, #1377, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w6, #22996, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w7, #4877, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w19, #37345, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w20, #5862, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w21, #22996, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w22, #59726, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w23, #1377, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w24, #22996, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w25, #30851, lsl #16
-// FLAT-ANDROID-NEXT:	movk	w26, #4877, lsl #16
-// FLAT-ANDROID-NEXT:	stur	w11, [x29, #-4]
-// FLAT-ANDROID-NEXT:	b	.LBB0_4
-
+// FLAT-ANDROID:            mov	w16, #114
+// FLAT-ANDROID-NEXT:   	movk	w17, #47507, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w2, #37211, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w3, #60668, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w4, #47507, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w5, #3652, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w6, #7153, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w7, #25844, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w19, #29878, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w20, #14846, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w21, #25844, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w22, #3652, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w23, #31029, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w24, #31029, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w25, #60668, lsl #16
+// FLAT-ANDROID-NEXT:   	movk	w26, #29878, lsl #16
+// FLAT-ANDROID-NEXT:   	stur	w11, [x29, #-4]
+// FLAT-ANDROID-NEXT:   	b	.LBB0_4
 
 int check_password(const char *passwd, unsigned len) {
   if (len != 5) {

--- a/src/test/passes/cfg-flattening/basic-arm-android.c
+++ b/src/test/passes/cfg-flattening/basic-arm-android.c
@@ -22,38 +22,40 @@
 // NO-FLAT-NEXT:    beq	.LBB0_4
 
 // FLAT-LABEL:    check_password:
-// FLAT-ARM:          	str	r1, [sp, #4]
-// FLAT-ARM-NEXT:	ldr	r1, .LCPI0_0
-// FLAT-ARM-NEXT:	str	r1, [sp, #16]
-// FLAT-ARM-NEXT:	ldr	r3, .LCPI0_1
-// FLAT-ARM-NEXT:	ldr	lr, .LCPI0_2
-// FLAT-ARM-NEXT:	ldr	r4, .LCPI0_3
-// FLAT-ARM-NEXT:	ldr	r5, .LCPI0_9
-// FLAT-ARM-NEXT:	ldr	r9, .LCPI0_4
-// FLAT-ARM-NEXT:	ldr	r8, .LCPI0_7
-// FLAT-ARM-NEXT:	ldr	r10, .LCPI0_5
-// FLAT-ARM-NEXT:	b	.LBB0_3
+// FLAT-ARM:         str	r1, [sp, #4]
+// FLAT-ARM-NEXT:    ldr	r1, .LCPI0_0
+// FLAT-ARM-NEXT:    str	r1, [sp, #16]
+// FLAT-ARM-NEXT:    ldr	r8, .LCPI0_1
+// FLAT-ARM-NEXT:    ldr	r2, .LCPI0_2
+// FLAT-ARM-NEXT:    ldr	r10, .LCPI0_3
+// FLAT-ARM-NEXT:    ldr	lr, .LCPI0_9
+// FLAT-ARM-NEXT:    ldr	r3, .LCPI0_13
+// FLAT-ARM-NEXT:    ldr	r4, .LCPI0_10
+// FLAT-ARM-NEXT:    ldr	r5, .LCPI0_11
+// FLAT-ARM-NEXT:    ldr	r9, .LCPI0_4
+// FLAT-ARM-NEXT:    b	.LBB0_2
 
 // FLAT-THUMB:        	str	r1, [sp, #4]
-// FLAT-THUMB-NEXT:	movw	r1, #53745
-// FLAT-THUMB-NEXT:	movt	r1, #29570
-// FLAT-THUMB-NEXT:	str	r1, [sp, #16]
-// FLAT-THUMB-NEXT:	movw	r3, #26518
-// FLAT-THUMB-NEXT:	movt	r3, #5862
-// FLAT-THUMB-NEXT:	movw	lr, #48522
-// FLAT-THUMB-NEXT:	movt	lr, #36449
-// FLAT-THUMB-NEXT:	movw	r4, #34130
-// FLAT-THUMB-NEXT:	movt	r4, #4877
-// FLAT-THUMB-NEXT:	movw	r5, #49955
-// FLAT-THUMB-NEXT:	movt	r5, #59726
-// FLAT-THUMB-NEXT:	movw	r9, #30077
-// FLAT-THUMB-NEXT:	movt	r9, #22996
-// FLAT-THUMB-NEXT:	movw	r8, #34131
-// FLAT-THUMB-NEXT:	movt	r8, #4877
-// FLAT-THUMB-NEXT:	movw	r10, #30078
-// FLAT-THUMB-NEXT:	movt	r10, #22996
-// FLAT-THUMB-NEXT:	b	.LBB0_3
-
+// FLAT-THUMB-NEXT:     movw	r1, #17966
+// FLAT-THUMB-NEXT:     movt	r1, #31462
+// FLAT-THUMB-NEXT:     str	r1, [sp, #16]
+// FLAT-THUMB-NEXT:     movw	r8, #61194
+// FLAT-THUMB-NEXT:     movt	r8, #14846
+// FLAT-THUMB-NEXT:     movw	r2, #13093
+// FLAT-THUMB-NEXT:     movt	r2, #29878
+// FLAT-THUMB-NEXT:     movw	r10, #61391
+// FLAT-THUMB-NEXT:     movt	r10, #14846
+// FLAT-THUMB-NEXT:     movw	lr, #26503
+// FLAT-THUMB-NEXT:     movt	lr, #60668
+// FLAT-THUMB-NEXT:     movw	r3, #53796
+// FLAT-THUMB-NEXT:     movt	r3, #37211
+// FLAT-THUMB-NEXT:     movw	r4, #26504
+// FLAT-THUMB-NEXT:     movt	r4, #60668
+// FLAT-THUMB-NEXT:     movw	r5, #32960
+// FLAT-THUMB-NEXT:     movt	r5, #3652
+// FLAT-THUMB-NEXT:     movw	r9, #13230
+// FLAT-THUMB-NEXT:     movt	r9, #29878
+// FLAT-THUMB-NEXT:     b	.LBB0_2
 
 int check_password(const char* passwd, unsigned len) {
   if (len != 5) {


### PR DESCRIPTION
The previous tarball generation was erroneous and the compiled LLVM toolchain did not reflect the exact version upon which NDK 29's clang is based on.