### PR TITLE
GitHub Workflows: Remove tarballs after extractions

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -54,7 +54,9 @@ python3.10 -m venv /tmp/omvll-doc-venv
 /tmp/omvll-doc-venv/bin/pip install sphinx furo
 
 # 2. Build the standalone module
-DEPS=~/Workspace/omvll-v1.4.0-macos-deps        # adjust to your deps tree
+# Dependencies for version X.Y.Z of O-MVLL can be downloaded via
+# https://open-obfuscator.build38.io/static/omvll-vX.Y.Z-macos-deps.tar
+DEPS=~/Workspace/omvll-v1.9.1-macos-deps
 LLVM=$DEPS/LLVM-21.1.6-arm64-Darwin
 PY=/opt/homebrew/opt/python@3.10
 

--- a/scripts/docker/ndk_r29_compile.sh
+++ b/scripts/docker/ndk_r29_compile.sh
@@ -13,13 +13,20 @@ cp /third-party/omvll-deps-ndk-*/pybind11.tar.gz .
 cp /third-party/omvll-deps-ndk-*/spdlog-1.10.0-Linux.tar.gz .
 
 tar xzvf android-llvm-toolchain-r29d.tar.gz
+rm android-llvm-toolchain-r29d.tar.gz
 tar xzvf Python-slim.tar.gz
+rm Python-slim.tar.gz
 tar xzvf pybind11.tar.gz
+rm pybind11.tar.gz
 tar xzvf spdlog-1.10.0-Linux.tar.gz
+rm spdlog-1.10.0-Linux.tar.gz
 
 tar xzvf android-llvm-toolchain-r29d/out.tar.gz -C android-llvm-toolchain-r29d
+rm android-llvm-toolchain-r29d/out.tar.gz
 tar xzvf android-llvm-toolchain-r29d/out/stage1-install.tar.gz -C android-llvm-toolchain-r29d/out
+rm android-llvm-toolchain-r29d/out/stage1-install.tar.gz
 tar xzvf android-llvm-toolchain-r29d/out/stage2.tar.gz -C android-llvm-toolchain-r29d/out
+rm android-llvm-toolchain-r29d/out/stage2.tar.gz
 
 # Android NDK is bootstrapped in a so-called 2-stage process. To avoid ABI incompatibilities,
 # we build our plugin with the same toolchain used to build the NDK itself (stage-1). Then,

--- a/scripts/docker/xcode_26_compile.sh
+++ b/scripts/docker/xcode_26_compile.sh
@@ -7,12 +7,24 @@
 set -ex
 
 cd /deps
+
 tar xzvf LLVM-21.1.6-arm64-Darwin.tar.gz
+rm LLVM-21.1.6-arm64-Darwin.tar.gz
+
 tar xzvf LLVM-21.1.6-x86_64-Darwin.tar.gz
+rm LLVM-21.1.6-x86_64-Darwin.tar.gz
+
 tar xzvf LLVM21-NDK29-Darwin.tar.gz
+rm LLVM21-NDK29-Darwin.tar.gz
+
 tar xzvf Python-slim.tar.gz
+rm Python-slim.tar.gz
+
 tar xzvf pybind11.tar.gz
+rm pybind11.tar.gz
+
 tar xzvf spdlog-1.10.0-Darwin.tar.gz
+rm spdlog-1.10.0-Darwin.tar.gz
 
 export OSXCROSS_TARGET_DIR=/osxcross
 export OSXCROSS_SDK=${OSXCROSS_TARGET_DIR}/SDK/MacOSX26.4.sdk


### PR DESCRIPTION
The CI tests were failing due to a lack of space left on disk.
+ We mitigate this by removing the large tarballs from the dependencies after extraction.

+ Clarifies dependencies in doc/README.md