### PR TITLE
StringEncoding: never encode ObjC selectors

### DIFF
--- a/src/passes/string-encoding/StringEncoding.cpp
+++ b/src/passes/string-encoding/StringEncoding.cpp
@@ -583,9 +583,9 @@ bool StringEncoding::encodeStrings(Function &F, ObfuscationConfig &UserConfig) {
            std::get_if<StringEncOptGlobal>(EncInfoOpt.get()) == nullptr))
         continue;
 
-      // Skip Objective-C method names/selectors with local encoding.
-      if (isObjCMethodName(*G) &&
-          std::get_if<StringEncOptLocal>(EncInfoOpt.get()))
+      // Skip ObjC selectors and class refs. Linker and runtime
+      // read these sections directly, so the bytes must stay intact
+      if (isObjCMethodName(*G))
         continue;
 
       if (std::get_if<StringEncOptLocal>(EncInfoOpt.get())) {


### PR DESCRIPTION
Selector and class-reference strings live in sections the linker and the ObjC runtime read directly. Encoding them scrambles the data ld::pass::analyzeObjc walks to build the selector table, crashing the linker on a null pointer. Skip these globals whatever encoding was requested, not just local, matching how isABICriticalGlobal already treats them in the aggregate path.