### PR TITLE
BreakCF: Fix linkage, swifterror and coroutine bugs

### DIFF
--- a/src/passes/break-cfg/BreakControlFlow.cpp
+++ b/src/passes/break-cfg/BreakControlFlow.cpp
@@ -48,7 +48,6 @@ static const uint8_t AArch64AsmBreakingStub[] = {
     0xF1, 0xFF, 0xF2, 0xA2, // raw bytes
     0xF8, 0xFF, 0xE2, 0xC2  // raw bytes
 };
-
 static constexpr size_t ARMInstSize = 4;
 static constexpr size_t ARMFunctionAlignment = 0x10;
 
@@ -73,6 +72,11 @@ static const uint8_t ARMAsmBreakingStub[] = {
     0x00, 0xBF, 0x00, 0xBF, 0x00, 0xBF,
     0x00, 0xBF, 0x00, 0xBF, 0x00, 0xBF};
 
+static bool hasSwiftErrorArg(const Function &F) {
+  return any_of(F.args(),
+                [](const Argument &Arg) { return Arg.hasSwiftErrorAttr(); });
+}
+
 bool BreakControlFlow::runOnFunction(Function &F) {
   if (F.getInstructionCount() == 0)
     return false;
@@ -84,6 +88,16 @@ bool BreakControlFlow::runOnFunction(Function &F) {
   if (F.isVarArg())
     return false;
 
+  if (isCoroutine(&F)) {
+    return false;
+  }
+
+  if (F.getCallingConv() == CallingConv::Swift && hasSwiftErrorArg(F)) {
+    SDEBUG("[{}] Skipping {}: swifterror argument forbids musttail", name(),
+           F.getName());
+    return false;
+  }
+
   const auto &TT = Triple(F.getParent()->getTargetTriple());
   if (!(TT.isAArch64() || TT.isARM() || TT.isThumb()))
     return false;
@@ -91,10 +105,14 @@ bool BreakControlFlow::runOnFunction(Function &F) {
   SINFO("[{}] Visiting function {}", name(), F.getName());
   ScopedTrace TracePassFunc(F.getName(), name());
 
+  // Function::deleteBody() resets the linkage to external
+  const GlobalValue::LinkageTypes Linkage = F.getLinkage();
+
   ValueToValueMapTy VMap;
   ClonedCodeInfo CCI;
   Function *ClonedF = CloneFunction(&F, VMap, &CCI);
   F.deleteBody();
+  F.setLinkage(Linkage);
 
   Function &Trampoline = F;
   const size_t InstSize = TT.isAArch64() ? AArch64InstSize : ARMInstSize;
@@ -205,10 +223,10 @@ bool BreakControlFlow::runOnFunction(Function &F) {
   CallingConv::ID CallConv = ClonedF->getCallingConv();
   Call->setCallingConv(CallConv);
 
-  // Only force musttail for swiftcc. This is the only convention
-  // that uses x8 as an implicit sret register on AArch64, which
-  // the trampoline's jump target overwrites.
-  if (CallConv == CallingConv::Swift) {
+  // Force musttail for swiftcc, which uses x8 as an implicit sret register on
+  // AArch64 that the trampoline's jump target overwrites, and for swifttailcc,
+  // where a tail call is part of the ABI
+  if (CallConv == CallingConv::Swift || CallConv == CallingConv::SwiftTail) {
     Call->setTailCallKind(CallInst::TCK_MustTail);
   }
 

--- a/src/test/passes/break-cfg/async-coroutine-aarch64-ios.swift
+++ b/src/test/passes/break-cfg/async-coroutine-aarch64-ios.swift
@@ -1,0 +1,48 @@
+//
+// This file is distributed under the Apache License v2.0. See LICENSE for
+// details.
+//
+
+// REQUIRES: apple_abi && aarch64-registered-target
+
+// Swift async functions are coroutines when this pass runs: LLVM splits them
+// into their continuation funclets ($s...TQ0_, $s...TY1_) later in the
+// pipeline. A funclet carved out of our clone inherits the clone's prologue
+// data, and the async runtime resumes it at its own symbol, landing in the
+// middle of the 32-byte breaking stub instead of on real code, which faults at
+// runtime. The pass must leave coroutines alone, so no swifttailcc function
+// may end up carrying prologue data.
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: env OMVLL_CONFIG=%S/config_all.py swift-frontend -frontend -c \
+// RUN:     -primary-file %s -target arm64-apple-ios17.5.0 -module-name breakcfg \
+// RUN:     -Onone -module-cache-path %t -load-pass-plugin=%libOMVLL -emit-ir \
+// RUN:     %EXTRA_SWIFT_FLAGS -o - \
+// RUN:   | FileCheck --implicit-check-not='define {{.*}}swifttailcc {{.*}}prologue' %s
+
+// The async machinery has to actually be there for the check above to mean
+// something, and the pass has to still be transforming the ordinary functions.
+
+// CHECK-DAG: define {{.*}}swifttailcc void @"$s8breakcfg4workyS2iYaF"
+// CHECK-DAG: define {{.*}}swifttailcc void @"$s8breakcfg4workyS2iYaFTQ0_"
+// CHECK-DAG: define internal swiftcc i64 @"$s8breakcfg4syncyS2iF.{{[0-9]+}}"{{.*}} prologue <32 x i8>
+
+@inline(never)
+func work(_ x: Int) async -> Int {
+  await Task.yield()
+  return x &* 3
+}
+
+@inline(never)
+public func run(_ x: Int) async -> Int {
+  var acc = 0
+  for i in 0 ..< 4 {
+    acc &+= await work(x &+ i)
+  }
+  return acc
+}
+
+@inline(never)
+public func sync(_ x: Int) -> Int {
+  return x &* 7 &+ 1
+}

--- a/src/test/passes/break-cfg/linkage-aarch64-ios.ll
+++ b/src/test/passes/break-cfg/linkage-aarch64-ios.ll
@@ -1,0 +1,51 @@
+;
+; This file is distributed under the Apache License v2.0. See LICENSE for details.
+;
+
+; REQUIRES: aarch64-registered-target && apple_abi
+
+; The pass moves the body of a function into a clone and turns the original
+; into a trampoline. Function::deleteBody() resets the linkage to external on
+; the way, so the trampoline has to be given the original linkage back.
+
+; RUN: env OMVLL_CONFIG=%S/config_all.py clang -fpass-plugin=%libOMVLL \
+; RUN:         -target arm64-apple-ios17.5.0 -O1 -S -emit-llvm %s -o - | FileCheck %s
+
+define linkonce_odr hidden i32 @linkonce_fn(i32 %x) noinline {
+entry:
+  %m = mul i32 %x, 7
+  ret i32 %m
+}
+
+define weak_odr i32 @weak_fn(i32 %x) noinline {
+entry:
+  %m = mul i32 %x, 11
+  ret i32 %m
+}
+
+define internal i32 @internal_fn(i32 %x) noinline {
+entry:
+  %m = mul i32 %x, 13
+  ret i32 %m
+}
+
+define i32 @use(i32 %x) {
+entry:
+  %a = call i32 @linkonce_fn(i32 %x)
+  %b = call i32 @weak_fn(i32 %a)
+  %c = call i32 @internal_fn(i32 %b)
+  ret i32 %c
+}
+
+; Each original function is now a trampoline whose body was moved to an
+; internal clone carrying the breaking stub as prologue data.
+
+; CHECK-DAG: define internal i32 @linkonce_fn.{{[0-9]+}}({{.*}} prologue <32 x i8>
+; CHECK-DAG: define internal i32 @weak_fn.{{[0-9]+}}({{.*}} prologue <32 x i8>
+; CHECK-DAG: define internal i32 @internal_fn.{{[0-9]+}}({{.*}} prologue <32 x i8>
+
+; The trampolines keep the linkage of the functions they replaced.
+
+; CHECK-DAG: define linkonce_odr hidden i32 @linkonce_fn(i32 {{%.*}}) {{.*}}{
+; CHECK-DAG: define weak_odr i32 @weak_fn(i32 {{%.*}}) {{.*}}{
+; CHECK-DAG: define internal {{.*}}i32 @internal_fn(i32 {{%.*}}) {{.*}}{

--- a/src/test/passes/break-cfg/swifterror-aarch64-ios.ll
+++ b/src/test/passes/break-cfg/swifterror-aarch64-ios.ll
@@ -1,0 +1,67 @@
+;
+; This file is distributed under the Apache License v2.0. See LICENSE for details.
+;
+
+; REQUIRES: aarch64-registered-target && apple_abi
+
+; The trampoline emitted for a swiftcc function performs a musttail call, which
+; AArch64 cannot honour when the function takes a swifterror argument: it is
+; passed in x21, a callee-saved register, and SelectionDAG tracks it in its own
+; virtual register rather than the register's live-in value. Lowering aborts
+; with "failed to perform tail call elimination on a call site marked musttail",
+; so the pass must leave those functions alone. Every Swift `throws` function
+; has a swifterror argument.
+
+; RUN: env OMVLL_CONFIG=%S/config_all.py clang -fpass-plugin=%libOMVLL \
+; RUN:         -target arm64-apple-ios17.5.0 -O1 -S -emit-llvm %s -o - \
+; RUN:   | FileCheck --implicit-check-not=@throwing_fn. %s
+
+; Lowering the module all the way down to assembly must not abort.
+
+; RUN: env OMVLL_CONFIG=%S/config_all.py clang -fpass-plugin=%libOMVLL \
+; RUN:         -target arm64-apple-ios17.5.0 -O1 -S %s -o /dev/null
+
+; The swifterror function keeps its body: no clone (checked module-wide by the
+; --implicit-check-not above), no prologue data on its definition line, and no
+; musttail call in it.
+
+; CHECK-LABEL: define swiftcc i64 @throwing_fn({{.*}}) local_unnamed_addr #{{[0-9]+}} {
+; CHECK:         store ptr inttoptr (i64 1 to ptr), ptr %err
+; CHECK-NOT:     musttail
+
+; A swiftcc function without swifterror is broken as usual: the body moves to a
+; clone carrying the breaking stub as prologue data, and the original becomes a
+; musttail trampoline branching past that stub. Both end up after the untouched
+; functions in the module.
+
+; CHECK-LABEL: define internal swiftcc i64 @plain_fn.{{[0-9]+}}(
+; CHECK-SAME:    prologue <32 x i8>
+; CHECK-LABEL: define swiftcc i64 @plain_fn(
+; CHECK:         musttail call swiftcc i64
+
+define swiftcc i64 @plain_fn(i64 %x, ptr swiftself %self) noinline {
+entry:
+  %cmp = icmp slt i64 %x, 0
+  br i1 %cmp, label %fail, label %ok
+
+fail:
+  ret i64 0
+
+ok:
+  %mul = mul i64 %x, 3
+  ret i64 %mul
+}
+
+define swiftcc i64 @throwing_fn(i64 %x, ptr swiftself %self, ptr swifterror %err) noinline {
+entry:
+  %cmp = icmp slt i64 %x, 0
+  br i1 %cmp, label %fail, label %ok
+
+fail:
+  store ptr inttoptr (i64 1 to ptr), ptr %err, align 8
+  ret i64 0
+
+ok:
+  %mul = mul i64 %x, 3
+  ret i64 %mul
+}


### PR DESCRIPTION
Three separate small issues detected by testing O-MVLL on an iOS sample app:

- Since `Function::deleteBody` resets linkage to external, the trampoline has to be given the original linkage back.
- Coroutines are not supported by the pass. Bail out.
- Since AArch64 can't tail-call a function with a `swifterror` argument, and the trampoline forces `musttail` for swiftcc, those functions have to be skipped. Also force `musttail` for swifttailcc