### PR TITLE
BBDuplicate: chain cloned blocks together

### DIFF
--- a/src/passes/basic-block-duplicate/BasicBlockDuplicate.cpp
+++ b/src/passes/basic-block-duplicate/BasicBlockDuplicate.cpp
@@ -28,6 +28,64 @@ namespace omvll {
 static constexpr auto LRand48FunctionName = "lrand48";
 static constexpr unsigned MaxDuplicatedBlocksPerFunction = 500;
 
+// A duplicated block is split in three: `Head` keeps the PHI nodes and hosts
+// the coinflip, while the rest of the original block lives in two twins (the
+// original tail and its clone)
+static bool canBypassHead(const BasicBlock &Head, const BasicBlock &Twin) {
+  if (!Head.phis().empty())
+    return false;
+
+  for (const Instruction &I : Twin)
+    for (const Value *Op : I.operands())
+      if (const auto *OpI = dyn_cast<Instruction>(Op))
+        if (OpI->getParent() == &Head)
+          return false;
+
+  return true;
+}
+
+// Chain the cloned blocks together
+static void redirectClonesToClonedSuccessors(
+    ArrayRef<BasicBlock *> Clones,
+    const DenseMap<BasicBlock *, BasicBlock *> &CloneOf) {
+  for (BasicBlock *Clone : Clones) {
+    Instruction *Term = Clone->getTerminator();
+
+    // Successors of these terminators are tied to blockaddress operands or to
+    // EH constraints, leave them alone
+    if (isa<IndirectBrInst>(Term) || isa<CallBrInst>(Term))
+      continue;
+
+    for (unsigned Idx = 0, E = Term->getNumSuccessors(); Idx != E; ++Idx) {
+      BasicBlock *Succ = Term->getSuccessor(Idx);
+      if (Succ->isEHPad())
+        continue;
+
+      auto It = CloneOf.find(Succ);
+      if (It == CloneOf.end())
+        continue;
+
+      BasicBlock *SuccClone = It->second;
+      if (SuccClone == Clone || !canBypassHead(*Succ, *SuccClone))
+        continue;
+
+      // `Clone` becomes a predecessor of `SuccClone`, taking over the incoming
+      // values that used to flow in through `Succ`.
+      bool HasIncomingFromHead =
+          llvm::all_of(SuccClone->phis(), [&](const PHINode &PN) {
+            return PN.getBasicBlockIndex(Succ) >= 0;
+          });
+      if (!HasIncomingFromHead)
+        continue;
+
+      for (PHINode &PN : SuccClone->phis())
+        PN.addIncoming(PN.getIncomingValueForBlock(Succ), Clone);
+
+      Term->setSuccessor(Idx, SuccClone);
+    }
+  }
+}
+
 static Value *buildCoinflip(IRBuilder<> &Builder, Module &M) {
     LLVMContext &Ctx = M.getContext();
 
@@ -63,6 +121,11 @@ bool BasicBlockDuplicate::process(Function &F, LLVMContext &Ctx,
   if (ToDup.empty())
     return false;
 
+  // Maps a duplicated block onto the clone of its tail, so that cloned blocks
+  // can be chained together once every block has been processed
+  DenseMap<BasicBlock *, BasicBlock *> CloneOf;
+  SmallVector<BasicBlock *, 64> Clones;
+
   IRBuilder<> Builder(Ctx);
   for (BasicBlock *BB : ToDup) {
     BasicBlock::iterator SplitIt = BB->getFirstNonPHIIt();
@@ -96,9 +159,8 @@ bool BasicBlockDuplicate::process(Function &F, LLVMContext &Ctx,
       }
     }
 
-    // TODO: Should also need a mapping cloned block to their successors, and
-    // adjust the cloned block terminator (if its successors have been cloned
-    // too).
+    CloneOf[BB] = NewBB;
+    Clones.push_back(NewBB);
 
     // Rebuild SSA form by inserting missing phi nodes at merge points.
     SmallVector<PHINode *, 8> NewPHIs;
@@ -136,6 +198,10 @@ bool BasicBlockDuplicate::process(Function &F, LLVMContext &Ctx,
       }
     }
   }
+
+  // Done once SSA form has been rebuilt everywhere: the PHI nodes inserted
+  // above decide whether a given head can be bypassed or not.
+  redirectClonesToClonedSuccessors(Clones, CloneOf);
 
   SDEBUG("[{}] Basic blocks duplicated: {}", name(), ToDup.size());
   return true;

--- a/src/test/passes/basic-block-duplicate/clone-successors-aarch64-ios.ll
+++ b/src/test/passes/basic-block-duplicate/clone-successors-aarch64-ios.ll
@@ -1,0 +1,76 @@
+;
+; This file is distributed under the Apache License v2.0. See LICENSE for details.
+;
+
+; REQUIRES: aarch64-registered-target && apple_abi
+
+; RUN: env OMVLL_CONFIG=%S/config_all.py clang++ -fpass-plugin=%libOMVLL \
+; RUN:         -target arm64-apple-ios17.5.0 -O0 -S -emit-llvm %s -o %t.ll
+; RUN: FileCheck --check-prefix=CHAIN %s < %t.ll
+; RUN: FileCheck --check-prefix=MERGE %s < %t.ll
+
+; When the successor of a duplicated block has been duplicated as well, the
+; cloned block must branch to the cloned successor instead of falling back into
+; the original chain.
+
+define void @chain(ptr %p) {
+; CHAIN-LABEL: define void @chain(
+; CHAIN-SAME: ptr [[P:%.*]])
+; CHAIN:       {{^}}a.split.clone:
+; CHAIN-NEXT:    store i32 1, ptr [[P]]
+; CHAIN-NEXT:    br label %b.split.clone
+; CHAIN:       {{^}}b.split.clone:
+; CHAIN-NEXT:    store i32 2, ptr [[P]]
+; CHAIN-NEXT:    br label %c.split.clone
+; CHAIN:       {{^}}c.split.clone:
+; CHAIN-NEXT:    store i32 3, ptr [[P]]
+; CHAIN-NEXT:    ret void
+;
+entry:
+  br label %a
+
+a:
+  store i32 1, ptr %p
+  br label %b
+
+b:
+  store i32 2, ptr %p
+  br label %c
+
+c:
+  store i32 3, ptr %p
+  ret void
+}
+
+; A head block holding PHI nodes cannot be bypassed: rerouting the edge onto
+; the cloned tail would skip the PHI nodes altogether. The cloned blocks must
+; keep branching to the original successor here.
+
+define i32 @merge(i32 %x) {
+; MERGE-LABEL: define i32 @merge(
+; MERGE-SAME: i32 [[X:%.*]])
+; MERGE:       {{^}}m:
+; MERGE-NEXT:    [[PN:%.*]] = phi i32 [ [[A:%.*]], %t.split ], [ [[B:%.*]], %f.split ], [ [[A_CLONE:%.*]], %t.split.clone ], [ [[B_CLONE:%.*]], %f.split.clone ]
+; MERGE:       {{^}}t.split.clone:
+; MERGE-NEXT:    [[A_CLONE]] = add i32 [[X]], 1
+; MERGE-NEXT:    br label %m
+; MERGE:       {{^}}f.split.clone:
+; MERGE-NEXT:    [[B_CLONE]] = mul i32 [[X]], 3
+; MERGE-NEXT:    br label %m
+;
+entry:
+  %c = icmp sgt i32 %x, 0
+  br i1 %c, label %t, label %f
+
+t:
+  %a = add i32 %x, 1
+  br label %m
+
+f:
+  %b = mul i32 %x, 3
+  br label %m
+
+m:
+  %p = phi i32 [ %a, %t ], [ %b, %f ]
+  ret i32 %p
+}


### PR DESCRIPTION
A cloned block inherited its origin's terminator, so it always branched back into the original chain even when its successors had been duplicated too. Record each duplicated block's clone and, once SSA form is rebuilt, retarget those edges onto the cloned successors, skipping any head that still carries PHI nodes.